### PR TITLE
feat: add context menu entries for 3D visualizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,22 @@
         "icon": "$(graph)"
       }
     ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "gcode.openVisualizer",
+          "when": "editorLangId == gcode",
+          "group": "navigation"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "gcode.openVisualizer",
+          "when": "resourceLangId == gcode",
+          "group": "navigation"
+        }
+      ]
+    },
     "semanticTokenScopes": [
       {
         "language": "gcode",

--- a/src/client/CommandProvider.ts
+++ b/src/client/CommandProvider.ts
@@ -51,23 +51,45 @@ export class CommandProvider {
 
   /**
    * Register the command that opens (or refreshes) the 3D visualizer panel.
+   *
+   * Accepts an optional `uri` parameter so the command can be invoked from
+   * the file-explorer context menu (which passes the selected file's URI).
    */
   private registerOpenVisualizerCommand(context: vscode.ExtensionContext): vscode.Disposable {
-    return vscode.commands.registerCommand('gcode.openVisualizer', (): void => {
-      const editor = vscode.window.activeTextEditor;
+    return vscode.commands.registerCommand(
+      'gcode.openVisualizer',
+      async (uri?: vscode.Uri): Promise<void> => {
+        const documentText = await this.resolveDocumentText(uri);
+        if (documentText === null) {
+          vscode.window.showWarningMessage(
+            'Open a G-Code file first, then run "G-Code: Open 3D Visualizer".'
+          );
+          return;
+        }
 
-      if (!editor || editor.document.languageId !== GCODE_LANGUAGE_ID) {
-        vscode.window.showWarningMessage(
-          'Open a G-Code file first, then run "G-Code: Open 3D Visualizer".'
-        );
-        return;
+        const pathData = this.visualizerService.extractToolPath(documentText);
+        const settings = this.readVisualizerSettings();
+
+        GCodeVisualizerPanel.createOrShow(context, pathData, settings);
       }
+    );
+  }
 
-      const pathData = this.visualizerService.extractToolPath(editor.document.getText());
-      const settings = this.readVisualizerSettings();
+  /**
+   * Resolves the G-code text content from a URI (explorer context menu)
+   * or the active text editor. Returns null if no valid G-code source is found.
+   */
+  private async resolveDocumentText(uri?: vscode.Uri): Promise<string | null> {
+    if (uri) {
+      const document = await vscode.workspace.openTextDocument(uri);
+      return document.getText();
+    }
 
-      GCodeVisualizerPanel.createOrShow(context, pathData, settings);
-    });
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== GCODE_LANGUAGE_ID) {
+      return null;
+    }
+    return editor.document.getText();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add right-click context menu entries for "Open 3D Visualizer" in both the editor and file explorer
- Update command handler to accept an optional `Uri` argument for explorer context menu invocations
- Extract `resolveDocumentText` helper method to cleanly handle both URI-based and active-editor-based text resolution

## Test plan
- [x] `npm test` — all 523 unit tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint` — no lint errors
- [ ] Manual: Open a G-code file, right-click in editor — verify "Open 3D Visualizer" appears
- [ ] Manual: Right-click a `.ngc` file in explorer — verify menu item appears
- [ ] Manual: Right-click a `.ts` file in explorer — verify menu item does NOT appear
- [ ] Manual: Command Palette invocation still works

Closes #30