### PR TITLE
test: expand visualizer test coverage

### DIFF
--- a/src/test/GCodePathExtractor.test.ts
+++ b/src/test/GCodePathExtractor.test.ts
@@ -119,6 +119,52 @@ describe('GCodePathExtractor', () => {
     expect(arcSeg.points[0]).toEqual({ x: 5, y: 0, z: 0 });
   });
 
+  it('handles arc with zero radius gracefully', () => {
+    const data = extract('G2 X0 Y0 I0 J0');
+    expect(data.segments).toHaveLength(1);
+    // Zero radius -> should produce start+end points only
+    expect(data.segments[0].points.length).toBeLessThanOrEqual(2);
+  });
+
+  it('handles arc with missing I/J (defaults to 0)', () => {
+    const data = extract('G2 X10 Y0');
+    expect(data.segments).toHaveLength(1);
+  });
+
+  it('handles multiple arcs in sequence', () => {
+    const data = extract('G2 X10 Y0 I5 J0\nG3 X0 Y0 I-5 J0');
+    expect(data.segments).toHaveLength(2);
+    expect(data.segments[0].type).toBe(MotionType.ARC_CW);
+    expect(data.segments[1].type).toBe(MotionType.ARC_CCW);
+    // Both arcs should have interpolated points
+    expect(data.segments[0].points.length).toBeGreaterThan(2);
+    expect(data.segments[1].points.length).toBeGreaterThan(2);
+  });
+
+  it('handles full circle arc (start == end with non-zero I/J)', () => {
+    // Full circle: start and end are the same point, centre offset by I
+    const data = extract('G1 X10 Y0\nG2 X10 Y0 I-5 J0');
+    const arcSeg = data.segments[1];
+    expect(arcSeg.type).toBe(MotionType.ARC_CW);
+    // Full circle should produce many interpolated points
+    expect(arcSeg.points.length).toBeGreaterThan(10);
+    // First and last points should be the same (start == end)
+    const first = arcSeg.points[0];
+    const last = arcSeg.points[arcSeg.points.length - 1];
+    expect(first.x).toBeCloseTo(last.x, 5);
+    expect(first.y).toBeCloseTo(last.y, 5);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Negative axis values
+  // ---------------------------------------------------------------------------
+
+  it('handles negative axis values with unary minus', () => {
+    const data = extract('G1 X-10 Y-20 Z-5');
+    expect(data.segments).toHaveLength(1);
+    expect(data.segments[0].points[1]).toEqual({ x: -10, y: -20, z: -5 });
+  });
+
   // ---------------------------------------------------------------------------
   // Non-motion commands are ignored
   // ---------------------------------------------------------------------------

--- a/src/test/webviewTemplate.test.ts
+++ b/src/test/webviewTemplate.test.ts
@@ -1,0 +1,43 @@
+import { generateNonce, buildWebviewHtml } from '../client/webviewTemplate';
+import { DEFAULT_VISUALIZER_SETTINGS } from '../visualizer/types';
+
+describe('generateNonce', () => {
+  it('returns a 32-character hex string', () => {
+    const nonce = generateNonce();
+    expect(nonce).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('generates unique values', () => {
+    const nonces = new Set(Array.from({ length: 100 }, () => generateNonce()));
+    expect(nonces.size).toBe(100);
+  });
+});
+
+describe('buildWebviewHtml', () => {
+  it('returns a string containing expected HTML elements', () => {
+    const nonce = generateNonce();
+    const html = buildWebviewHtml(nonce, DEFAULT_VISUALIZER_SETTINGS);
+
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain(`nonce-${nonce}`);
+    expect(html).toContain(`<script nonce="${nonce}">`);
+    expect(html).toContain('<canvas id="canvas">');
+    expect(html).toContain('G-Code 3D Visualizer');
+  });
+
+  it('embeds the provided settings values', () => {
+    const nonce = generateNonce();
+    const settings = {
+      rapidColor: '#ff0000',
+      feedColor: '#00ff00',
+      arcColor: '#0000ff',
+      lineThickness: 2.5,
+    };
+    const html = buildWebviewHtml(nonce, settings);
+
+    expect(html).toContain(`value="${settings.rapidColor}"`);
+    expect(html).toContain(`value="${settings.feedColor}"`);
+    expect(html).toContain(`value="${settings.arcColor}"`);
+    expect(html).toContain(`value="${settings.lineThickness}"`);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/test/webviewTemplate.test.ts` with tests for `generateNonce` (format, uniqueness) and `buildWebviewHtml` (HTML structure, settings embedding)
- Add arc edge case tests to `GCodePathExtractor.test.ts`: zero-radius arc, missing I/J defaults, multiple arcs in sequence, full-circle arc
- Add test for negative axis values with unary minus (`G1 X-10 Y-20 Z-5`)

## Test plan
- [x] `npm test` -- all 592 tests pass
- [x] `npx tsc --noEmit` -- no type errors
- [x] `npm run lint` -- no lint errors

Closes #8 (from epic #27)