### PR TITLE
docs: add TDD workflow to project guidelines

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -76,6 +76,7 @@ Four supported dialects defined in `DialectType` enum (`src/constants.ts`): `lin
 - Conventional commit messages (`feat:`, `fix:`, `refactor:`, etc.)
 - Prefer classes over functions, enums over union types for fixed sets
 - Named constants for magic numbers/strings
+- **TDD for logic-heavy code** — write failing tests first for parsers, visitors, analyzers, formatters, services; skip TDD for pure boilerplate/wiring
 
 ## Development principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,11 +173,24 @@ All new code must:
 
 AST nodes, visitors, and services must be tested independently.
 
+### 8. Test-Driven Development (TDD)
+
+Use TDD for all logic-heavy code (parsers, visitors, analyzers, formatters, services):
+
+1. **Write a failing test first** — derive test cases from the spec or acceptance criteria
+2. **Implement until the test passes** — write the minimal code to satisfy the test
+3. **Refactor** — clean up while tests stay green
+4. **Repeat** for each unit of work
+
+Skip TDD for pure boilerplate: handler registration in `server.ts`, thin VS Code adapters, factory methods with no branching logic.
+
+Tests should operate at the service layer: feed G-code through the lexer/parser to produce an AST, then assert against the service output. This matches the existing test patterns in `src/test/`.
+
 ---
 
 ## Formatting & Style
 
-### 8. Code Style
+### 9. Code Style
 
 - Small files
 - One primary responsibility per file


### PR DESCRIPTION
## Summary

- Adds **TDD section (§8)** to `AGENTS.md` with the red-green-refactor cycle and clear guidance on when to skip TDD (boilerplate/wiring)
- Adds TDD bullet to **Key rules from AGENTS.md** in `.claude/CLAUDE.md`
- Also updated **global `~/.claude/CLAUDE.md`** Feature Workflow step 5 (outside this repo, not in the diff)

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | New §8 "Test-Driven Development (TDD)" with 4-step cycle, skip criteria, and service-layer testing guidance. Renumbered §8 Code Style → §9 |
| `.claude/CLAUDE.md` | Added TDD bullet to "Key rules from AGENTS.md" section |

## Test plan

- [ ] Verify AGENTS.md renders correctly and numbering is consistent
- [ ] Verify .claude/CLAUDE.md bullet aligns with AGENTS.md §8