### PR TITLE
docs: replace placeholder changelog with actual release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,5 @@
 # Changelog
 
-## [v2.1.0] - 2026-04-01
-
-### Added
-- New features and improvements
-
-### Changed
-- Updates and modifications
-
-### Fixed
-- Bug fixes
-
-
-## [v2.0.0] - 2026-03-29
-
-### Added
-- New features and improvements
-
-### Changed
-- Updates and modifications
-
-### Fixed
-- Bug fixes
-
-
-## [v1.1.0] - 2026-02-19
-
-### Added
-- New features and improvements
-
-### Changed
-- Updates and modifications
-
-### Fixed
-- Bug fixes
-
-
 All notable changes to the "G-Code Language Support" extension will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -44,70 +8,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- ✨ Configurable G-code dialect support (LinuxCNC, Fanuc, Haas, Siemens)
-  - Dialect-specific completions and documentation
-  - Dialect-specific formatting with control flow syntax variations
-  - Factory pattern for extensible dialect architecture
-  - IDataProvider interface for dialect abstraction
-  - IFormatter interface for formatter abstraction
-  - Runtime dialect switching without VS Code reload
-  - Per-document dialect support for mixed-dialect workspaces
-- 🛡️ Robust error handling and recovery
-  - Parser preserves original text when encountering unsupported syntax
-  - ErrorNode captures parse errors with original line context
-  - Formatter outputs error comments (ERROR: message) with original code
-  - LineNumberNode and SubroutineLabelNode for proper label handling
-  - Graceful degradation - continues parsing after errors instead of crashing
-- 🧪 Comprehensive dialect-specific test coverage
-  - Separate test files for each dialect formatter (LinuxCNC, Fanuc, Haas, Siemens)
-  - Separate test files for each dialect provider (DocumentFormatting, RangeFormatting)
-  - 89 new tests covering dialect variations and error handling
-- Contributing guidelines
-- Development documentation
-- Architecture documentation
+- Complete G/M code command databases for all four dialects (#70)
+- Diagnostic severity levels (Error, Warning, Information, Hint) in error reporting (#71)
+- Go to Definition and Find References for variables (#72)
 
-## [0.3.0] - 2025-01-XX
+### Fixed
+- Unsafe enum comparison lint error in DocumentSymbolVisitor
+
+## [v2.1.0] - 2026-04-01
 
 ### Added
-- Language Server Protocol (LSP) architecture
-- Document formatting support
-- Range formatting support
-- Comprehensive G-Code parser with AST generation
-- Customizable formatting options:
-  - Line number addition (N-blocks)
-  - Pretty printing for G/M codes
-  - Pretty printing for numbers
-  - Indentation for control structures
-  - Compact output mode
-- Support for 50+ G-Code file extensions
-- Custom G-Code theme
-- Format on save support
+- Subroutine parsing across all dialects — `SUB`/`ENDSUB`, `M98`/`M99`, `PROC`/`RET`, and O-word subroutines (#63)
+- Subroutine formatting across all dialects with dialect-specific syntax (#65)
+- Hierarchical document outline — symbols grouped by subroutine, IF/WHILE blocks shown as children (#69)
 
 ### Changed
-- Migrated to LSP-based architecture for better performance
-- Improved parser performance with hand-written recursive descent parser
-- Enhanced formatter with more options
+- Redesigned lexer from moo-based tokenizer to hand-written character scanner (`GCodeScanner`) with case-insensitive keyword lookup table (#60)
+- Extracted multi-dialect parser architecture — `BaseParser` with dialect-specific subclasses (`LinuxCNCParser`, `FanucParser`, `HaasParser`, `SiemensParser`) and `ParserFactory` (#62)
 
-### Technical
-- TypeScript strict mode
-- Comprehensive test coverage
-- Jest testing framework
-- Worker pool for formatting operations
-
-## [0.2.0] - 2025-01-XX
+## [v2.0.0] - 2026-03-29
 
 ### Added
-- Initial formatter implementation
-- Basic parser functionality
+- **3D G-code tool-path visualizer** — interactive 3D view of cutting paths with orbit, pan, and zoom
+  - Expression evaluator for resolving variables and arithmetic in G-code
+  - Interpreter with WHILE loop and IF/ELSE evaluation for accurate path extraction
+  - Off-thread parsing with loading indicator for large files (#43)
+  - Reference grid overlay (#44)
+  - Configurable visualization settings (colors, line width, grid) (#45)
+  - Motion context data (feed rate, spindle speed, tool number) on path segments (#47)
+  - Segment hover, selection, and info panel (#48)
+  - Source code navigation — click a segment to jump to the corresponding G-code line (#49)
+  - Arc plane selection (G17/G18/G19) and G28 home position support (#53)
+  - Syntax highlighting in tooltip source line (#57)
+  - Live-update on document change with debounced refresh
+  - Error display in webview panel
+  - Context menu entry ("Open 3D Visualizer") for G-code files
+- Code folding for IF/WHILE/subroutine blocks (#25)
+- Error detection to block formatting on files with syntax errors
+- Modal G-code support for standalone axis parameters (e.g., bare `X10 Y20` lines)
 
-## [0.0.1] - 2025-01-XX
+### Changed
+- Extracted webview into separate HTML/CSS/TypeScript files for maintainability (#41)
+- Introduced shared configuration provider for consistent settings access (#56)
+
+### Fixed
+- 3D visualizer renders with Z-axis pointing up (was inverted)
+- Lint and formatting violations in visualizer code
+
+## [v1.1.0] - 2026-02-19
 
 ### Added
-- Initial release
-- Syntax highlighting for G-Code files
-- Basic document formatting
-- Custom G-Code theme
-- Support for common G-Code file extensions (.nc, .ngc, .g, .gc)
+- Configurable G-code dialect support (LinuxCNC, Fanuc, Haas, Siemens)
+  - Dialect-specific completions and hover documentation
+  - Dialect-specific formatting with control flow syntax variations
+  - Factory pattern for extensible dialect architecture (`FormatterFactory`, `DataProviderFactory`)
+  - `IDataProvider` interface for dialect-level command/function/operator data
+  - Runtime dialect switching without VS Code reload
+  - Per-document dialect support for mixed-dialect workspaces
+- Language Server Protocol (LSP) architecture
+- Document formatting and range formatting
+- Hover information — variable values, G/M command descriptions, operator and function docs
+- Document symbols — variable outline in explorer
+- Variable renaming across document
+- Document highlights — highlight all occurrences of a variable
+- Semantic token-based syntax highlighting
+- Comprehensive G-Code parser with AST generation (recursive descent)
+- Customizable formatting options: line numbers, pretty-print commands/numbers, indentation, compact output
+- Robust error handling and recovery
+  - Parser preserves original text on unsupported syntax
+  - `ErrorNode` captures parse errors with original line context
+  - Graceful degradation — continues parsing after errors
+- Support for 50+ G-Code file extensions
+- Custom G-Code color theme
+- Format on save support
+- Contributing guidelines and architecture documentation
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,10 +268,14 @@ Understanding the codebase:
 
 - `src/client/extension.ts`: Extension entry point
 - `src/server/server.ts`: LSP server implementation
-- `src/parser/GCodeParser.ts`: Main parser logic
-- `src/formatter/GCodeFormatter.ts`: Main formatter logic
-- `src/providers/SemanticTokensProvider.ts`: Semantic token highlighting
-- `src/providers/DocumentFormattingProvider.ts`: Document formatting
+- `src/lexer/GCodeScanner.ts`: Hand-written character scanner
+- `src/parser/BaseParser.ts`: Abstract parser base with shared logic
+- `src/parser/ParserFactory.ts`: Dialect-specific parser selection
+- `src/formatter/BaseFormatter.ts`: Abstract formatter base (visitor-based)
+- `src/providers/CompletionProvider.ts`: Dialect-aware IntelliSense
+- `src/providers/DefinitionProvider.ts`: Go to Definition for variables
+- `src/providers/DiagnosticsProvider.ts`: Error and warning reporting
+- `src/client/GCodeVisualizerPanel.ts`: 3D visualizer webview panel
 
 ## Common Tasks
 
@@ -295,7 +299,7 @@ Understanding the codebase:
 ### Improving Parser
 
 1. Understand the AST structure in `src/parser/nodes/`
-2. Modify `src/parser/GCodeParser.ts` or `src/parser/AstFactory.ts`
+2. Modify the relevant dialect parser in `src/parser/dialects/` or shared logic in `src/parser/BaseParser.ts`
 3. Add test cases in `src/test/GCodeParser.test.ts`
 4. Ensure all existing tests pass (unit and e2e)
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,31 @@ A Visual Studio Code extension providing comprehensive G-Code language support w
 
 ## Features
 
-- **Syntax Highlighting**: Full syntax highlighting for G-Code files with support for 50+ file extensions
-- **Document Formatting**: Intelligent formatting with customizable options
-- **Robust Error Handling**: Parser gracefully handles unsupported syntax
-  - Preserves original code when encountering parse errors
-  - Inserts error comments with diagnostic information
-  - Continues parsing after errors for maximum code preservation
+- **3D Tool-Path Visualizer**: Interactive 3D view of cutting paths with orbit, pan, and zoom
+  - Segment hover, selection, and info panel (feed rate, spindle speed, tool number)
+  - Click-to-navigate from 3D segments to source G-code lines
+  - Arc plane support (G17/G18/G19) and G28 home position
+  - Reference grid, configurable colors and line widths
+  - Off-thread parsing with loading indicator for large files
+  - Live-update on document change
+- **Syntax Highlighting**: Semantic token-based highlighting for G-Code files with 50+ file extensions
+- **Document Formatting**: Intelligent formatting with customizable options and dialect-specific syntax
+- **Completions**: Dialect-aware IntelliSense for G/M commands, parameters, variables, functions, and operators
+- **Go to Definition / Find References**: Navigate to variable assignments and find all usages
 - **Hover Information**: Intelligent tooltips showing:
   - Variable values and declarations
   - G/M command descriptions with parameters and examples
   - Operator and function documentation
   - Axis parameter meanings
-- **Symbol Navigation**: Document outline showing all variables
+- **Symbol Navigation**: Hierarchical document outline — symbols grouped by subroutine with IF/WHILE blocks as children
+- **Code Folding**: Fold IF/WHILE/subroutine blocks
 - **Variable Renaming**: Rename variables across entire document
-- **Syntax Highlighting**: Semantic token-based highlighting
 - **Document Highlights**: Highlight all occurrences of a variable
+- **Diagnostics**: Syntax error reporting with severity levels (Error, Warning, Information, Hint)
+- **Subroutine Support**: Parsing and formatting of subroutines across all four dialects
+- **Robust Error Handling**: Parser gracefully handles unsupported syntax
+  - Preserves original code when encountering parse errors
+  - Continues parsing after errors for maximum code preservation
 - **Custom Theme**: Dedicated G-Code color theme for optimal readability
 - **Language Server**: LSP-based architecture for fast and reliable language features
 - **Format on Save**: Automatic formatting support
@@ -162,25 +172,31 @@ This extension contributes the following settings:
 
 ## Architecture
 
-This extension uses a Language Server Protocol (LSP) architecture:
+This extension uses a Language Server Protocol (LSP) architecture with a strict layered pipeline:
 
 ```
-┌─────────────────┐
-│  VS Code Client │
-│  (extension.ts) │
-└────────┬────────┘
-         │ IPC
-         │
-┌────────▼────────┐
-│ Language Server │
-│   (server.ts)   │
-└────────┬────────┘
+┌─────────────────┐   ┌──────────────────────┐
+│  VS Code Client │   │  3D Visualizer Panel  │
+│  (extension.ts) │   │  (webview + extractor)│
+└────────┬────────┘   └──────────┬───────────┘
+         │ IPC                   │
+         │                       │
+┌────────▼────────┐              │
+│ Language Server  │              │
+│   (server.ts)   │              │
+└────────┬────────┘              │
+         │                       │
+┌────────▼───────────────────────▼──┐
+│          Providers / Services     │
+│  (completions, hover, diagnostics,│
+│   formatting, symbols, folding)   │
+└────────┬──────────────────────────┘
          │
     ┌────┴────┬──────────┬────────────┐
     │         │          │            │
 ┌───▼───┐ ┌──▼───┐ ┌────▼────┐ ┌─────▼─────┐
-│ Lexer │ │Parser│ │Formatter│ │   Types   │
-└───────┘ └──────┘ └──────────┘ └───────────┘
+│ Lexer │ │Parser│ │Formatter│ │ Databases │
+└───────┘ └──────┘ └─────────┘ └───────────┘
 ```
 
 ### Project Structure
@@ -189,42 +205,53 @@ This extension uses a Language Server Protocol (LSP) architecture:
 src/
 ├── client/          # VS Code extension client
 │   ├── extension.ts # Extension entry point
-│   └── index.ts
+│   ├── CommandProvider.ts
+│   ├── GCodeVisualizerPanel.ts
+│   └── VisualizerService.ts
 ├── server/          # Language Server implementation
-│   ├── server.ts    # LSP server setup
-│   └── index.ts
-├── lexer/           # G-Code lexer (tokenizer)
-│   └── GCodeLexer.ts
-├── parser/          # G-Code parser (AST generation)
-│   ├── GCodeParser.ts
+│   └── server.ts    # LSP server setup
+├── lexer/           # Hand-written character scanner
+│   ├── GCodeScanner.ts
+│   ├── GCodeLexer.ts
+│   └── LexerFactory.ts
+├── parser/          # Multi-dialect parser (AST generation)
+│   ├── BaseParser.ts
+│   ├── ParserFactory.ts
 │   ├── AstFactory.ts
 │   ├── AstTraverser.ts
 │   ├── AstVisitor.ts
-│   └── nodes/       # AST node definitions
+│   ├── BaseAstVisitor.ts
+│   ├── nodes/       # AST node definitions
+│   └── dialects/    # LinuxCNC, Fanuc, Haas, Siemens parsers
 ├── formatter/       # Code formatter
 │   ├── BaseFormatter.ts
 │   ├── FormatterFactory.ts
 │   ├── ExpressionFormatter.ts
 │   └── dialects/    # Dialect-specific formatters
-│       ├── LinuxCNCFormatter.ts
-│       ├── FanucFormatter.ts
-│       ├── HaasFormatter.ts
-│       └── SiemensFormatter.ts
-├── databases/       # G-Code command databases
-│   ├── GCodeCommandDatabase.ts
+├── databases/       # G/M-code command reference data
 │   └── dialects/    # Dialect-specific databases
-├── providers/       # Language feature providers
+├── visualizer/      # 3D tool-path extraction (VS Code-free)
+│   ├── GCodePathExtractor.ts
+│   ├── GCodeInterpreter.ts
+│   └── GCodeExpressionEvaluator.ts
+├── webview/         # 3D visualizer webview (HTML/CSS/JS)
+├── providers/       # LSP service layer
+│   ├── CompletionProvider.ts
+│   ├── DefinitionProvider.ts
+│   ├── ReferencesProvider.ts
+│   ├── DiagnosticsProvider.ts
 │   ├── DocumentFormattingProvider.ts
 │   ├── DocumentSymbolProvider.ts
 │   ├── DocumentHighlightProvider.ts
+│   ├── FoldingRangeProvider.ts
 │   ├── HoverProvider.ts
 │   ├── RenameProvider.ts
 │   ├── SemanticTokensProvider.ts
 │   ├── DataProviderFactory.ts
-│   └── dialects/    # Dialect-specific providers
+│   └── dialects/    # Dialect-specific data providers
 ├── test/            # Unit tests (Jest)
-│   └── fixtures/    # Test fixtures
-└── e2e/             # E2E tests (VS Code)
+│   └── fixtures/    # Test fixtures (.nc files)
+└── e2e/             # E2E tests (VS Code Extension Host)
     ├── suite/       # Test suites
     └── fixtures/    # Test fixtures
 ```
@@ -330,12 +357,25 @@ None at this time. Please report issues on [GitHub Issues](https://github.com/Qu
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
 
-### Version 0.3.0
+### Version 2.1.0
 
-- LSP-based architecture
-- Document and range formatting
-- Comprehensive G-Code parser
-- Customizable formatting options
+- Hand-written lexer redesign for better performance and dialect handling
+- Multi-dialect parser architecture with per-dialect subclasses
+- Subroutine parsing and formatting across all four dialects
+- Hierarchical document outline
+
+### Version 2.0.0
+
+- 3D G-code tool-path visualizer with interactive navigation
+- Code folding for control structures
+- Error detection to block formatting on syntax errors
+- Modal G-code support for standalone axis parameters
+
+### Version 1.1.0
+
+- Configurable dialect support (LinuxCNC, Fanuc, Haas, Siemens)
+- LSP architecture with formatting, hover, symbols, rename, and semantic tokens
+- Robust error handling and recovery
 
 ## License
 
@@ -344,7 +384,6 @@ MIT License - see [LICENSE](LICENSE) file for details.
 ## Acknowledgments
 
 - Built with [VS Code Language Server Protocol](https://microsoft.github.io/language-server-protocol/)
-- Uses [moo](https://github.com/no-context/moo) for lexing
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaced placeholder changelog entries ("New features and improvements", "Bug fixes") for v1.1.0, v2.0.0, and v2.1.0 with real release notes reconstructed from git commit history
- Updated README.md: added missing features (3D visualizer, completions, Go to Definition, code folding, diagnostics, subroutines), fixed project structure to match current codebase, updated architecture diagram, updated release notes section, removed stale "Uses moo for lexing" acknowledgment
- Updated CONTRIBUTING.md: fixed outdated file references (GCodeParser.ts → BaseParser.ts, added new key files like GCodeScanner, CompletionProvider, DiagnosticsProvider)

## Test plan

- [ ] Verify CHANGELOG.md entries match the actual git history between version bumps
- [ ] Verify README.md project structure matches `src/` directory layout
- [ ] Verify no broken markdown links

Closes #77

https://claude.ai/code/session_01GkZpNkyt1FUNQR9VCpGJn7