### PR TITLE
feat: add dialect-aware axis parameter validation

### DIFF
--- a/src/lexer/GCodeScanner.ts
+++ b/src/lexer/GCodeScanner.ts
@@ -1,5 +1,5 @@
 import { DialectType } from '../constants';
-import { getKeywordEntries, SINGLE_CHAR_TOKEN_MAP } from './constants';
+import { getKeywordEntries, getValidParamLetters, SINGLE_CHAR_TOKEN_MAP } from './constants';
 import { LexerToken, TokenOptions } from './LexerToken';
 import { KeywordType, TokenCategory } from './types';
 
@@ -41,10 +41,12 @@ export class GCodeScanner {
   private offsetBase: number = 0;
   private tokens: LexerToken[] = [];
   private readonly keywordMap: ReadonlyMap<string, KeywordType>;
+  private readonly validParamLetters: ReadonlySet<string>;
   private readonly scanHandlers: ReadonlyMap<string, () => void>;
 
   constructor(dialect: DialectType = DialectType.LINUXCNC) {
     this.keywordMap = new Map(getKeywordEntries(dialect));
+    this.validParamLetters = getValidParamLetters(dialect);
     this.scanHandlers = new Map<string, () => void>([
       ['\r', () => this.scanNewline()],
       ['\n', () => this.scanNewline()],
@@ -192,7 +194,10 @@ export class GCodeScanner {
     // (e.g., X, Y, Z, F, S followed by number or whitespace).
     // Underscore is not a valid G-code parameter letter.
     if (upperFirstChar >= 'A' && upperFirstChar <= 'Z' && firstChar !== '_') {
-      this.emit(TokenCategory.PARAM, null, firstChar, startOffset, startLine, startCol);
+      const category = this.validParamLetters.has(upperFirstChar)
+        ? TokenCategory.PARAM
+        : TokenCategory.IDENTIFIER;
+      this.emit(category, null, firstChar, startOffset, startLine, startCol);
       return;
     }
 

--- a/src/lexer/constants.ts
+++ b/src/lexer/constants.ts
@@ -175,3 +175,47 @@ export function getKeywordEntries(
       return LINUXCNC_KEYWORDS;
   }
 }
+
+/**
+ * Valid single-letter parameter characters shared across all dialects.
+ * These are letters that can appear as axis words or parameter prefixes.
+ */
+const COMMON_PARAM_LETTERS: ReadonlySet<string> = new Set([
+  'X',
+  'Y',
+  'Z', // Linear axes
+  'A',
+  'B',
+  'C', // Rotary axes
+  'I',
+  'J',
+  'K', // Arc center offsets
+  'F', // Feed rate
+  'S', // Spindle speed
+  'T', // Tool number
+  'H',
+  'D', // Tool offsets
+  'P',
+  'L',
+  'R',
+  'Q', // Cycle/subroutine parameters
+]);
+
+const LINUXCNC_PARAM_LETTERS: ReadonlySet<string> = new Set([
+  ...COMMON_PARAM_LETTERS,
+  'U',
+  'V',
+  'W', // Extra linear axes (LinuxCNC 9-axis)
+]);
+
+/**
+ * Returns the set of valid single-letter parameter characters for the given dialect.
+ */
+export function getValidParamLetters(dialect: DialectType): ReadonlySet<string> {
+  switch (dialect) {
+    case DialectType.LINUXCNC:
+      return LINUXCNC_PARAM_LETTERS;
+    default:
+      return COMMON_PARAM_LETTERS;
+  }
+}

--- a/src/test/GCodeScanner.test.ts
+++ b/src/test/GCodeScanner.test.ts
@@ -444,24 +444,24 @@ describe('GCodeScanner', () => {
   });
 
   describe('ambiguous single-letter tokens', () => {
-    it('should tokenize bare O as PARAM (not OSUB)', () => {
+    it('should tokenize bare O as IDENTIFIER (not OSUB)', () => {
       const tokens = scanner.tokenize('O');
-      expect(tokens[0].category).toBe(TokenCategory.PARAM);
+      expect(tokens[0].category).toBe(TokenCategory.IDENTIFIER);
     });
 
-    it('should tokenize bare G as PARAM (not GCODE)', () => {
+    it('should tokenize bare G as IDENTIFIER (not GCODE)', () => {
       const tokens = scanner.tokenize('G');
-      expect(tokens[0].category).toBe(TokenCategory.PARAM);
+      expect(tokens[0].category).toBe(TokenCategory.IDENTIFIER);
     });
 
-    it('should tokenize bare M as PARAM (not MCODE)', () => {
+    it('should tokenize bare M as IDENTIFIER (not MCODE)', () => {
       const tokens = scanner.tokenize('M');
-      expect(tokens[0].category).toBe(TokenCategory.PARAM);
+      expect(tokens[0].category).toBe(TokenCategory.IDENTIFIER);
     });
 
-    it('should tokenize bare N as PARAM (not LINE_NUMBER)', () => {
+    it('should tokenize bare N as IDENTIFIER (not LINE_NUMBER)', () => {
       const tokens = scanner.tokenize('N');
-      expect(tokens[0].category).toBe(TokenCategory.PARAM);
+      expect(tokens[0].category).toBe(TokenCategory.IDENTIFIER);
     });
   });
 
@@ -935,6 +935,54 @@ describe('GCodeScanner', () => {
       for (const token of tokens) {
         expect(token.unterminated).toBe(false);
       }
+    });
+  });
+
+  describe('dialect-aware parameter validation', () => {
+    it('should emit common axis letters as PARAM in all dialects', () => {
+      const dialects = [
+        DialectType.LINUXCNC,
+        DialectType.FANUC,
+        DialectType.HAAS,
+        DialectType.SIEMENS,
+      ];
+      for (const dialect of dialects) {
+        const dialectScanner = new GCodeScanner(dialect);
+        for (const letter of ['X', 'Y', 'Z', 'A', 'B', 'C', 'F', 'S', 'T']) {
+          const tokens = dialectScanner.tokenize(`${letter}10`);
+          expect(tokens[0].category).toBe(TokenCategory.PARAM);
+        }
+      }
+    });
+
+    it('should emit U, V, W as PARAM in LinuxCNC only', () => {
+      const linuxScanner = new GCodeScanner(DialectType.LINUXCNC);
+      const fanucScanner = new GCodeScanner(DialectType.FANUC);
+
+      for (const letter of ['U', 'V', 'W']) {
+        const linuxTokens = linuxScanner.tokenize(`${letter}10`);
+        expect(linuxTokens[0].category).toBe(TokenCategory.PARAM);
+
+        const fanucTokens = fanucScanner.tokenize(`${letter}10`);
+        expect(fanucTokens[0].category).toBe(TokenCategory.IDENTIFIER);
+      }
+    });
+
+    it('should emit invalid letter E as IDENTIFIER', () => {
+      const tokens = scanner.tokenize('E');
+      expect(tokens[0].category).toBe(TokenCategory.IDENTIFIER);
+    });
+
+    it('should emit H, D, P, L, R, Q as PARAM (tool/cycle parameters)', () => {
+      for (const letter of ['H', 'D', 'P', 'L', 'R', 'Q']) {
+        const tokens = scanner.tokenize(`${letter}5`);
+        expect(tokens[0].category).toBe(TokenCategory.PARAM);
+      }
+    });
+
+    it('should handle lowercase parameter letters', () => {
+      const tokens = scanner.tokenize('x10');
+      expect(tokens[0].category).toBe(TokenCategory.PARAM);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds per-dialect validation of axis parameter letters in the scanner. Previously, any single ASCII letter A-Z was unconditionally emitted as `TokenCategory.PARAM`. Now, only letters recognized by the current dialect produce `PARAM` tokens — others become `IDENTIFIER`.

### Changes

- `COMMON_PARAM_LETTERS` and `LINUXCNC_PARAM_LETTERS` sets in `constants.ts`
- `getValidParamLetters(dialect)` function returns the correct set per dialect
- Scanner checks letters against dialect set before emitting `PARAM`
- LinuxCNC-specific axes `U`, `V`, `W` are `PARAM` only in LinuxCNC dialect

| Dialect | Letters |
|---------|---------|
| All | X Y Z A B C I J K F S T H D P L R Q |
| LinuxCNC | + U V W (9-axis support) |

## Test plan

- [x] 5 new tests in `GCodeScanner.test.ts` (dialect-aware parameter validation)
- [x] 4 existing ambiguous-token tests updated (bare O, G, M, N → IDENTIFIER)
- [x] Typecheck clean, lint clean
- [x] Needs rebase onto current main

Closes #99

https://claude.ai/code/session_01GkZpNkyt1FUNQR9VCpGJn7