### PR TITLE
feat: add ViewCube navigation gizmo (#121)

### DIFF
--- a/src/test/viewCube/animation.test.ts
+++ b/src/test/viewCube/animation.test.ts
@@ -127,6 +127,20 @@ describe('animateCamera', () => {
     expect(camera.theta).toBeGreaterThanOrEqual((3 * Math.PI) / 4 - 0.01);
   });
 
+  it('snaps instantly when duration is zero', () => {
+    const camera = createCamera(0, 0);
+    const onFrame = jest.fn();
+    const onComplete = jest.fn();
+
+    animateCamera(camera, { theta: Math.PI / 2, phi: Math.PI / 4 }, 0, onFrame, onComplete);
+
+    expect(camera.theta).toBe(Math.PI / 2);
+    expect(camera.phi).toBe(Math.PI / 4);
+    expect(onFrame).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
   it('does nothing when already at target', () => {
     const camera = createCamera(Math.PI / 2, Math.PI / 4);
     const onFrame = jest.fn();

--- a/src/test/viewCube/animation.test.ts
+++ b/src/test/viewCube/animation.test.ts
@@ -47,12 +47,16 @@ describe('animateCamera', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     let frameId = 0;
+    let frameTime = 0;
+    const frameDurationMs = 16;
     // rAF doesn't exist in Node — define stubs so spyOn can attach
     globalThis.requestAnimationFrame = (() => 0) as typeof requestAnimationFrame;
     globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
     jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
       frameId++;
-      setTimeout(() => cb(performance.now()), 0);
+      frameTime += frameDurationMs;
+      const scheduledFrameTime = frameTime;
+      setTimeout(() => cb(scheduledFrameTime), frameDurationMs);
       return frameId;
     });
     jest.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {

--- a/src/test/viewCube/animation.test.ts
+++ b/src/test/viewCube/animation.test.ts
@@ -1,0 +1,143 @@
+import { animateCamera, normalizeAngle } from '../../webview/viewCube/animation';
+import { CameraState } from '../../webview/types';
+
+function createCamera(theta = 0, phi = 0): CameraState {
+  return {
+    theta,
+    phi,
+    radius: 200,
+    panX: 0,
+    panY: 0,
+    target: { x: 0, y: 0, z: 0 },
+  };
+}
+
+describe('normalizeAngle', () => {
+  it('returns 0 for delta of 0', () => {
+    expect(normalizeAngle(0)).toBe(0);
+  });
+
+  it('wraps positive delta > PI to negative', () => {
+    // 3PI/2 should become -PI/2 (shorter path)
+    const result = normalizeAngle((3 * Math.PI) / 2);
+    expect(result).toBeCloseTo(-Math.PI / 2);
+  });
+
+  it('wraps negative delta < -PI to positive', () => {
+    // -3PI/2 should become PI/2
+    const result = normalizeAngle((-3 * Math.PI) / 2);
+    expect(result).toBeCloseTo(Math.PI / 2);
+  });
+
+  it('keeps delta within [-PI, PI] unchanged', () => {
+    expect(normalizeAngle(Math.PI / 4)).toBeCloseTo(Math.PI / 4);
+    expect(normalizeAngle(-Math.PI / 4)).toBeCloseTo(-Math.PI / 4);
+  });
+
+  it('normalizes exactly PI to PI', () => {
+    expect(normalizeAngle(Math.PI)).toBeCloseTo(Math.PI);
+  });
+
+  it('normalizes exactly -PI to -PI', () => {
+    expect(normalizeAngle(-Math.PI)).toBeCloseTo(-Math.PI);
+  });
+});
+
+describe('animateCamera', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    let frameId = 0;
+    // rAF doesn't exist in Node — define stubs so spyOn can attach
+    globalThis.requestAnimationFrame = (() => 0) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+    jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+      frameId++;
+      setTimeout(() => cb(performance.now()), 0);
+      return frameId;
+    });
+    jest.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {
+      // no-op in test
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('snaps camera to exact target values after animation completes', () => {
+    const camera = createCamera(0, 0);
+    const onFrame = jest.fn();
+    const onComplete = jest.fn();
+
+    animateCamera(camera, { theta: Math.PI / 2, phi: Math.PI / 4 }, 100, onFrame, onComplete);
+
+    // Advance past the animation duration
+    jest.advanceTimersByTime(200);
+
+    expect(camera.theta).toBe(Math.PI / 2);
+    expect(camera.phi).toBe(Math.PI / 4);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onFrame during animation', () => {
+    const camera = createCamera(0, 0);
+    const onFrame = jest.fn();
+
+    animateCamera(camera, { theta: Math.PI / 2, phi: 0 }, 100, onFrame);
+
+    jest.advanceTimersByTime(50);
+
+    expect(onFrame).toHaveBeenCalled();
+  });
+
+  it('cancel function stops the animation', () => {
+    const camera = createCamera(0, 0);
+    const onFrame = jest.fn();
+    const onComplete = jest.fn();
+
+    const cancel = animateCamera(
+      camera,
+      { theta: Math.PI / 2, phi: Math.PI / 4 },
+      100,
+      onFrame,
+      onComplete
+    );
+
+    cancel();
+    jest.advanceTimersByTime(200);
+
+    // Camera should NOT have reached the target
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('takes shortest angular path for theta', () => {
+    // Start at theta=3PI/4, target theta=-3PI/4
+    // Direct delta is -3PI/2 but shortest path is PI/2 (go the other way)
+    const camera = createCamera((3 * Math.PI) / 4, 0);
+    const onFrame = jest.fn();
+
+    animateCamera(camera, { theta: (-3 * Math.PI) / 4, phi: 0 }, 100, onFrame);
+
+    // After partial progress, theta should have moved in the positive direction
+    // (shorter path from 3PI/4 to -3PI/4 is via PI)
+    jest.advanceTimersByTime(50);
+
+    // Theta should be somewhere between 3PI/4 and PI (not going backwards through 0)
+    expect(camera.theta).toBeGreaterThanOrEqual((3 * Math.PI) / 4 - 0.01);
+  });
+
+  it('does nothing when already at target', () => {
+    const camera = createCamera(Math.PI / 2, Math.PI / 4);
+    const onFrame = jest.fn();
+    const onComplete = jest.fn();
+
+    animateCamera(camera, { theta: Math.PI / 2, phi: Math.PI / 4 }, 100, onFrame, onComplete);
+
+    jest.advanceTimersByTime(200);
+
+    expect(camera.theta).toBe(Math.PI / 2);
+    expect(camera.phi).toBe(Math.PI / 4);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test/viewCube/views.test.ts
+++ b/src/test/viewCube/views.test.ts
@@ -1,0 +1,67 @@
+import { FACE_VIEWS, EDGE_VIEWS } from '../../webview/viewCube/views';
+
+const POLE_MARGIN = 0.01;
+
+describe('ViewCube view definitions', () => {
+  describe('FACE_VIEWS', () => {
+    it('defines exactly 6 faces', () => {
+      expect(Object.keys(FACE_VIEWS)).toHaveLength(6);
+    });
+
+    it('defines Front view at theta=0, phi=0', () => {
+      expect(FACE_VIEWS.Front).toEqual({ theta: 0, phi: 0 });
+    });
+
+    it('defines Back view at theta=PI, phi=0', () => {
+      expect(FACE_VIEWS.Back).toEqual({ theta: Math.PI, phi: 0 });
+    });
+
+    it('defines Right view at theta=-PI/2, phi=0', () => {
+      expect(FACE_VIEWS.Right).toEqual({ theta: -Math.PI / 2, phi: 0 });
+    });
+
+    it('defines Left view at theta=PI/2, phi=0', () => {
+      expect(FACE_VIEWS.Left).toEqual({ theta: Math.PI / 2, phi: 0 });
+    });
+
+    it('defines Top view at theta=0, phi near PI/2', () => {
+      expect(FACE_VIEWS.Top).toEqual({ theta: 0, phi: Math.PI / 2 - POLE_MARGIN });
+    });
+
+    it('defines Bottom view at theta=0, phi near -PI/2', () => {
+      expect(FACE_VIEWS.Bottom).toEqual({ theta: 0, phi: -Math.PI / 2 + POLE_MARGIN });
+    });
+
+    it('all faces have phi within gimbal-safe range', () => {
+      for (const view of Object.values(FACE_VIEWS)) {
+        expect(view.phi).toBeGreaterThanOrEqual(-Math.PI / 2 + POLE_MARGIN);
+        expect(view.phi).toBeLessThanOrEqual(Math.PI / 2 - POLE_MARGIN);
+      }
+    });
+  });
+
+  describe('EDGE_VIEWS', () => {
+    it('defines exactly 12 edges', () => {
+      expect(Object.keys(EDGE_VIEWS)).toHaveLength(12);
+    });
+
+    it('defines Front-Top edge at theta=0, phi=PI/4', () => {
+      expect(EDGE_VIEWS['Front-Top']).toEqual({ theta: 0, phi: Math.PI / 4 });
+    });
+
+    it('defines Front-Right edge at theta=-PI/4, phi=0', () => {
+      expect(EDGE_VIEWS['Front-Right']).toEqual({ theta: -Math.PI / 4, phi: 0 });
+    });
+
+    it('defines Back-Right edge at theta=-3PI/4, phi=0', () => {
+      expect(EDGE_VIEWS['Back-Right']).toEqual({ theta: (-3 * Math.PI) / 4, phi: 0 });
+    });
+
+    it('all edges have phi within gimbal-safe range', () => {
+      for (const view of Object.values(EDGE_VIEWS)) {
+        expect(view.phi).toBeGreaterThanOrEqual(-Math.PI / 2 + POLE_MARGIN);
+        expect(view.phi).toBeLessThanOrEqual(Math.PI / 2 - POLE_MARGIN);
+      }
+    });
+  });
+});

--- a/src/test/viewCube/views.test.ts
+++ b/src/test/viewCube/views.test.ts
@@ -1,6 +1,5 @@
 import { FACE_VIEWS, EDGE_VIEWS } from '../../webview/viewCube/views';
-
-const POLE_MARGIN = 0.01;
+import { POLE_MARGIN } from '../../webview/constants';
 
 describe('ViewCube view definitions', () => {
   describe('FACE_VIEWS', () => {

--- a/src/webview/components/CanvasArea.tsx
+++ b/src/webview/components/CanvasArea.tsx
@@ -6,6 +6,7 @@ import { SegmentStats } from './SegmentStats';
 import { EmptyMessage } from './EmptyMessage';
 import { LoadingOverlay } from './LoadingOverlay';
 import { PlaybackBarWrapper } from './PlaybackBar';
+import { ViewCube } from './ViewCube';
 
 export function CanvasArea() {
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -22,6 +23,7 @@ export function CanvasArea() {
   return (
     <div id="canvas-wrapper" ref={wrapperRef}>
       <ToolPathCanvas wrapperRef={wrapperRef} />
+      <ViewCube />
       {segments.length === 0 && !loading && <EmptyMessage />}
       {loading && <LoadingOverlay />}
       <SegmentStats count={segments.length} />

--- a/src/webview/components/ToolPathCanvas.tsx
+++ b/src/webview/components/ToolPathCanvas.tsx
@@ -9,6 +9,7 @@ import {
   useVisualizerSettings,
   useTooltip,
   useCameraControls,
+  useCancelAnimation,
   useMousePosition,
 } from '../context/VisualizerContext';
 import { usePlaybackEngineRefs } from '../context/PlaybackContext';
@@ -35,6 +36,7 @@ export function ToolPathCanvas({ wrapperRef }: ToolPathCanvasProps) {
   const { settings } = useVisualizerSettings();
   const { visibleIndex, onHoverChange, onCursorMove, onCanvasLeave, onDragStart } = useTooltip();
   const { registerCameraControls, registerCameraState } = useCameraControls();
+  const cancelAnimation = useCancelAnimation();
   const { updateMousePosition } = useMousePosition();
 
   // Stable refs for latest values (used by imperative render/hit-test loops)
@@ -75,7 +77,11 @@ export function ToolPathCanvas({ wrapperRef }: ToolPathCanvasProps) {
       playbackRenderRefs
     );
 
-  const { camera, fitView, resetView, isDragging } = useCamera(canvasRef, scheduleRender);
+  const { camera, fitView, resetView, isDragging } = useCamera(
+    canvasRef,
+    scheduleRender,
+    cancelAnimation
+  );
   cameraRef.current = camera;
 
   // Hit testing — only call onHoverChange once per result (fixes issue #3)

--- a/src/webview/components/ToolPathCanvas.tsx
+++ b/src/webview/components/ToolPathCanvas.tsx
@@ -34,7 +34,7 @@ export function ToolPathCanvas({ wrapperRef }: ToolPathCanvasProps) {
   const { segments, bounds } = useDocumentState();
   const { settings } = useVisualizerSettings();
   const { visibleIndex, onHoverChange, onCursorMove, onCanvasLeave, onDragStart } = useTooltip();
-  const { registerCameraControls } = useCameraControls();
+  const { registerCameraControls, registerCameraState } = useCameraControls();
   const { updateMousePosition } = useMousePosition();
 
   // Stable refs for latest values (used by imperative render/hit-test loops)
@@ -95,7 +95,7 @@ export function ToolPathCanvas({ wrapperRef }: ToolPathCanvasProps) {
 
   const { scheduleHitTest } = useHitTesting(getProjectedCache, onHitTestResult);
 
-  // Expose camera controls to provider
+  // Expose camera controls and camera state to provider
   useEffect(() => {
     registerCameraControls({
       fitView,
@@ -105,6 +105,7 @@ export function ToolPathCanvas({ wrapperRef }: ToolPathCanvasProps) {
       clearProjectedCache,
       renderOverlay,
     });
+    registerCameraState(camera);
   }, [
     fitView,
     resetView,
@@ -113,6 +114,8 @@ export function ToolPathCanvas({ wrapperRef }: ToolPathCanvasProps) {
     clearProjectedCache,
     renderOverlay,
     registerCameraControls,
+    registerCameraState,
+    camera,
   ]);
 
   // Canvas resize

--- a/src/webview/components/ViewCube.tsx
+++ b/src/webview/components/ViewCube.tsx
@@ -40,22 +40,84 @@ interface EdgeDefinition {
 const EDGE_SIZE = 12; // hit area width in px
 const EDGE_LENGTH = CUBE_SIZE; // length along the edge
 
+// Edge transforms use translate3d for positioning + rotations for orientation.
+// CSS transforms apply right-to-left: rotation first, then translation in parent coords.
 const EDGE_DEFINITIONS: readonly EdgeDefinition[] = [
-  // Horizontal edges (connect side faces at same elevation)
-  { name: 'Front-Right', transform: `rotateY(45deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_SIZE, height: EDGE_LENGTH },
-  { name: 'Front-Left', transform: `rotateY(-45deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_SIZE, height: EDGE_LENGTH },
-  { name: 'Back-Right', transform: `rotateY(135deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_SIZE, height: EDGE_LENGTH },
-  { name: 'Back-Left', transform: `rotateY(-135deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_SIZE, height: EDGE_LENGTH },
-  // Top horizontal edges
-  { name: 'Front-Top', transform: `rotateX(45deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
-  { name: 'Back-Top', transform: `rotateX(45deg) rotateY(180deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
-  { name: 'Right-Top', transform: `rotateX(45deg) rotateY(90deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
-  { name: 'Left-Top', transform: `rotateX(45deg) rotateY(-90deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
-  // Bottom horizontal edges
-  { name: 'Front-Bottom', transform: `rotateX(-45deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
-  { name: 'Back-Bottom', transform: `rotateX(-45deg) rotateY(180deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
-  { name: 'Right-Bottom', transform: `rotateX(-45deg) rotateY(90deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
-  { name: 'Left-Bottom', transform: `rotateX(-45deg) rotateY(-90deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
+  // Vertical edges (run along CSS Y-axis at cube corners)
+  {
+    name: 'Front-Right',
+    transform: `translate3d(${HALF}px, 0, ${HALF}px) rotateY(45deg)`,
+    width: EDGE_SIZE,
+    height: EDGE_LENGTH,
+  },
+  {
+    name: 'Front-Left',
+    transform: `translate3d(${-HALF}px, 0, ${HALF}px) rotateY(-45deg)`,
+    width: EDGE_SIZE,
+    height: EDGE_LENGTH,
+  },
+  {
+    name: 'Back-Right',
+    transform: `translate3d(${HALF}px, 0, ${-HALF}px) rotateY(135deg)`,
+    width: EDGE_SIZE,
+    height: EDGE_LENGTH,
+  },
+  {
+    name: 'Back-Left',
+    transform: `translate3d(${-HALF}px, 0, ${-HALF}px) rotateY(-135deg)`,
+    width: EDGE_SIZE,
+    height: EDGE_LENGTH,
+  },
+  // Top edges (at y = -HALF in CSS coords)
+  {
+    name: 'Front-Top',
+    transform: `translate3d(0, ${-HALF}px, ${HALF}px) rotateX(45deg)`,
+    width: EDGE_LENGTH,
+    height: EDGE_SIZE,
+  },
+  {
+    name: 'Back-Top',
+    transform: `translate3d(0, ${-HALF}px, ${-HALF}px) rotateX(135deg)`,
+    width: EDGE_LENGTH,
+    height: EDGE_SIZE,
+  },
+  {
+    name: 'Right-Top',
+    transform: `translate3d(${HALF}px, ${-HALF}px, 0) rotateY(90deg) rotateX(45deg)`,
+    width: EDGE_LENGTH,
+    height: EDGE_SIZE,
+  },
+  {
+    name: 'Left-Top',
+    transform: `translate3d(${-HALF}px, ${-HALF}px, 0) rotateY(-90deg) rotateX(45deg)`,
+    width: EDGE_LENGTH,
+    height: EDGE_SIZE,
+  },
+  // Bottom edges (at y = +HALF in CSS coords)
+  {
+    name: 'Front-Bottom',
+    transform: `translate3d(0, ${HALF}px, ${HALF}px) rotateX(-45deg)`,
+    width: EDGE_LENGTH,
+    height: EDGE_SIZE,
+  },
+  {
+    name: 'Back-Bottom',
+    transform: `translate3d(0, ${HALF}px, ${-HALF}px) rotateX(-135deg)`,
+    width: EDGE_LENGTH,
+    height: EDGE_SIZE,
+  },
+  {
+    name: 'Right-Bottom',
+    transform: `translate3d(${HALF}px, ${HALF}px, 0) rotateY(90deg) rotateX(-45deg)`,
+    width: EDGE_LENGTH,
+    height: EDGE_SIZE,
+  },
+  {
+    name: 'Left-Bottom',
+    transform: `translate3d(${-HALF}px, ${HALF}px, 0) rotateY(-90deg) rotateX(-45deg)`,
+    width: EDGE_LENGTH,
+    height: EDGE_SIZE,
+  },
 ];
 
 /**
@@ -66,14 +128,14 @@ const EDGE_DEFINITIONS: readonly EdgeDefinition[] = [
  * - phi: elevation from XY plane
  *
  * CSS 3D uses Y-up by default, so we map:
- * - rotateX(-phi in degrees) for elevation (negated: CSS rotateX positive
- *   tilts top away from viewer, but positive phi should tilt top toward viewer)
- * - rotateZ(theta in degrees) for azimuth
+ * - rotateX(-phi) for elevation (CSS rotateX positive tilts top away,
+ *   but positive phi means looking up, so we negate)
+ * - rotateY(theta) for azimuth (CSS Y axis = vertical = visualizer Z axis)
  */
 function cameraToCSS(theta: number, phi: number): string {
   const thetaDeg = (theta * 180) / Math.PI;
   const phiDeg = (phi * 180) / Math.PI;
-  return `rotateX(${-phiDeg}deg) rotateZ(${thetaDeg}deg)`;
+  return `rotateX(${-phiDeg}deg) rotateY(${thetaDeg}deg)`;
 }
 
 export function ViewCube() {
@@ -120,16 +182,10 @@ export function ViewCube() {
       // Cancel any in-progress animation
       cancelAnimationRef.current?.();
 
-      const cancel = animateCamera(
-        camera,
-        view,
-        ANIMATION_DURATION,
-        scheduleRender,
-        () => {
-          cancelAnimationRef.current = null;
-          registerAnimationCancel(null);
-        }
-      );
+      const cancel = animateCamera(camera, view, ANIMATION_DURATION, scheduleRender, () => {
+        cancelAnimationRef.current = null;
+        registerAnimationCancel(null);
+      });
 
       cancelAnimationRef.current = cancel;
       registerAnimationCancel(cancel);
@@ -236,6 +292,10 @@ export function ViewCube() {
               transform: edge.transform,
               width: `${edge.width}px`,
               height: `${edge.height}px`,
+              left: '50%',
+              top: '50%',
+              marginLeft: `${-edge.width / 2}px`,
+              marginTop: `${-edge.height / 2}px`,
             }}
             onClick={() => handleEdgeClick(edge.name)}
           />

--- a/src/webview/components/ViewCube.tsx
+++ b/src/webview/components/ViewCube.tsx
@@ -140,38 +140,40 @@ function cameraToCSS(theta: number, phi: number): string {
 
 export function ViewCube() {
   const cameraRef = useCameraRef();
-  const scheduleRender = useScheduleRender();
+  const baseScheduleRender = useScheduleRender();
   const { registerAnimationCancel } = useAnimationCancel();
 
   const cubeRef = useRef<HTMLDivElement>(null);
   const cancelAnimationRef = useRef<(() => void) | null>(null);
   const isDraggingRef = useRef(false);
   const dragStartRef = useRef({ x: 0, y: 0 });
-  const rafIdRef = useRef<number | null>(null);
+  const lastSyncedAnglesRef = useRef({ theta: NaN, phi: NaN });
 
-  // Sync cube CSS transform to camera state on every animation frame.
-  // Dirty check avoids DOM writes when the camera is stationary.
-  useEffect(() => {
-    let prevTheta = NaN;
-    let prevPhi = NaN;
+  // Sync cube CSS transform to match current camera angles.
+  // Only writes to DOM when theta/phi have actually changed.
+  const syncCubeTransform = useCallback((): void => {
+    const camera = cameraRef.current;
+    const cube = cubeRef.current;
+    if (!camera || !cube) return;
 
-    function syncTransform(): void {
-      const camera = cameraRef.current;
-      const cube = cubeRef.current;
-      if (camera && cube && (camera.theta !== prevTheta || camera.phi !== prevPhi)) {
-        prevTheta = camera.theta;
-        prevPhi = camera.phi;
-        cube.style.transform = cameraToCSS(camera.theta, camera.phi);
-      }
-      rafIdRef.current = requestAnimationFrame(syncTransform);
-    }
-    rafIdRef.current = requestAnimationFrame(syncTransform);
-    return () => {
-      if (rafIdRef.current !== null) {
-        cancelAnimationFrame(rafIdRef.current);
-      }
-    };
+    const last = lastSyncedAnglesRef.current;
+    if (camera.theta === last.theta && camera.phi === last.phi) return;
+
+    last.theta = camera.theta;
+    last.phi = camera.phi;
+    cube.style.transform = cameraToCSS(camera.theta, camera.phi);
   }, [cameraRef]);
+
+  // Wrap scheduleRender to also sync the cube transform on every render.
+  const scheduleRender = useCallback((): void => {
+    syncCubeTransform();
+    baseScheduleRender();
+  }, [baseScheduleRender, syncCubeTransform]);
+
+  // Sync cube transform once on mount; subsequent updates piggyback on render scheduling.
+  useEffect(() => {
+    syncCubeTransform();
+  }, [syncCubeTransform]);
 
   // Navigate to a predefined view
   const navigateTo = useCallback(
@@ -210,6 +212,7 @@ export function ViewCube() {
           // Cancel any in-progress animation when drag starts
           cancelAnimationRef.current?.();
           cancelAnimationRef.current = null;
+          registerAnimationCancel(null);
           // Reset drag start to current position for smooth initial movement
           dragStartRef.current = { x: moveEvent.clientX, y: moveEvent.clientY };
           return;
@@ -240,7 +243,7 @@ export function ViewCube() {
       window.addEventListener('mousemove', handleMouseMove);
       window.addEventListener('mouseup', handleMouseUp);
     },
-    [cameraRef, scheduleRender]
+    [cameraRef, scheduleRender, registerAnimationCancel]
   );
 
   // Handle click on a face (only fires if not dragging)
@@ -263,6 +266,19 @@ export function ViewCube() {
     [navigateTo]
   );
 
+  // Handle keyboard activation on faces/edges
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent, name: string, isEdge: boolean) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        const views = isEdge ? EDGE_VIEWS : FACE_VIEWS;
+        const view = views[name];
+        if (view) navigateTo(view);
+      }
+    },
+    [navigateTo]
+  );
+
   // Cleanup animation on unmount
   useEffect(() => {
     return () => {
@@ -279,7 +295,11 @@ export function ViewCube() {
             key={name}
             className="view-cube-face"
             style={{ transform: FACE_TRANSFORMS[name] }}
+            role="button"
+            tabIndex={0}
+            aria-label={`${name} view`}
             onClick={() => handleFaceClick(name)}
+            onKeyDown={(e) => handleKeyDown(e, name, false)}
           >
             {name.toUpperCase()}
           </div>
@@ -297,7 +317,11 @@ export function ViewCube() {
               marginLeft: `${-edge.width / 2}px`,
               marginTop: `${-edge.height / 2}px`,
             }}
+            role="button"
+            tabIndex={0}
+            aria-label={`${edge.name} edge view`}
             onClick={() => handleEdgeClick(edge.name)}
+            onKeyDown={(e) => handleKeyDown(e, edge.name, true)}
           />
         ))}
       </div>

--- a/src/webview/components/ViewCube.tsx
+++ b/src/webview/components/ViewCube.tsx
@@ -312,8 +312,6 @@ export function ViewCube() {
               transform: edge.transform,
               width: `${edge.width}px`,
               height: `${edge.height}px`,
-              left: '50%',
-              top: '50%',
               marginLeft: `${-edge.width / 2}px`,
               marginTop: `${-edge.height / 2}px`,
             }}

--- a/src/webview/components/ViewCube.tsx
+++ b/src/webview/components/ViewCube.tsx
@@ -66,18 +66,14 @@ const EDGE_DEFINITIONS: readonly EdgeDefinition[] = [
  * - phi: elevation from XY plane
  *
  * CSS 3D uses Y-up by default, so we map:
- * - rotateX(phi in degrees) for elevation
+ * - rotateX(-phi in degrees) for elevation (negated: CSS rotateX positive
+ *   tilts top away from viewer, but positive phi should tilt top toward viewer)
  * - rotateZ(theta in degrees) for azimuth
- *
- * The signs are positive (not negated) because the cube represents the
- * scene, not the camera — when the camera orbits right (theta decreases),
- * the scene (and cube) appears to rotate left, which matches positive theta
- * in CSS rotateZ.
  */
 function cameraToCSS(theta: number, phi: number): string {
   const thetaDeg = (theta * 180) / Math.PI;
   const phiDeg = (phi * 180) / Math.PI;
-  return `rotateX(${phiDeg}deg) rotateZ(${thetaDeg}deg)`;
+  return `rotateX(${-phiDeg}deg) rotateZ(${thetaDeg}deg)`;
 }
 
 export function ViewCube() {

--- a/src/webview/components/ViewCube.tsx
+++ b/src/webview/components/ViewCube.tsx
@@ -1,0 +1,242 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { useCameraRef, useScheduleRender } from '../context/VisualizerContext';
+import { FACE_VIEWS, EDGE_VIEWS, ViewTarget } from '../viewCube/views';
+import { animateCamera } from '../viewCube/animation';
+
+/** Size of each cube face in CSS pixels. */
+const CUBE_SIZE = 80;
+
+/** Half the cube size — used for translateZ positioning. */
+const HALF = CUBE_SIZE / 2;
+
+/** Animation duration in milliseconds. */
+const ANIMATION_DURATION = 100;
+
+/** Orbit sensitivity in radians per pixel (matches interaction.ts). */
+const ORBIT_SENSITIVITY = 0.008;
+
+/** Minimum mouse movement in pixels to distinguish drag from click. */
+const DRAG_THRESHOLD = 3;
+
+/** Maximum phi to prevent gimbal lock (matches interaction.ts POLE_MARGIN). */
+const POLE_MARGIN = 0.01;
+
+/** CSS 3D transform for each face. */
+const FACE_TRANSFORMS: Record<string, string> = {
+  Front: `rotateY(0deg) translateZ(${HALF}px)`,
+  Back: `rotateY(180deg) translateZ(${HALF}px)`,
+  Right: `rotateY(90deg) translateZ(${HALF}px)`,
+  Left: `rotateY(-90deg) translateZ(${HALF}px)`,
+  Top: `rotateX(90deg) translateZ(${HALF}px)`,
+  Bottom: `rotateX(-90deg) translateZ(${HALF}px)`,
+};
+
+/**
+ * Edge definitions: each edge connects two faces and has a CSS 3D transform.
+ * The transform positions a narrow strip at the boundary between the two faces.
+ */
+interface EdgeDefinition {
+  readonly name: string;
+  readonly transform: string;
+  readonly width: number;
+  readonly height: number;
+}
+
+const EDGE_SIZE = 12; // hit area width in px
+const EDGE_LENGTH = CUBE_SIZE; // length along the edge
+
+const EDGE_DEFINITIONS: readonly EdgeDefinition[] = [
+  // Horizontal edges (connect side faces at same elevation)
+  { name: 'Front-Right', transform: `rotateY(45deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_SIZE, height: EDGE_LENGTH },
+  { name: 'Front-Left', transform: `rotateY(-45deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_SIZE, height: EDGE_LENGTH },
+  { name: 'Back-Right', transform: `rotateY(135deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_SIZE, height: EDGE_LENGTH },
+  { name: 'Back-Left', transform: `rotateY(-135deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_SIZE, height: EDGE_LENGTH },
+  // Top horizontal edges
+  { name: 'Front-Top', transform: `rotateX(45deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
+  { name: 'Back-Top', transform: `rotateX(45deg) rotateY(180deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
+  { name: 'Right-Top', transform: `rotateX(45deg) rotateY(90deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
+  { name: 'Left-Top', transform: `rotateX(45deg) rotateY(-90deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
+  // Bottom horizontal edges
+  { name: 'Front-Bottom', transform: `rotateX(-45deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
+  { name: 'Back-Bottom', transform: `rotateX(-45deg) rotateY(180deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
+  { name: 'Right-Bottom', transform: `rotateX(-45deg) rotateY(90deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
+  { name: 'Left-Bottom', transform: `rotateX(-45deg) rotateY(-90deg) translateZ(${HALF * Math.SQRT2}px)`, width: EDGE_LENGTH, height: EDGE_SIZE },
+];
+
+/**
+ * Converts camera spherical angles (theta, phi) to CSS 3D rotation.
+ *
+ * The visualizer uses Z-up convention:
+ * - theta: azimuth around Z axis
+ * - phi: elevation from XY plane
+ *
+ * CSS 3D uses Y-up by default, so we map:
+ * - rotateX(-phi in degrees) for elevation
+ * - rotateZ(-theta in degrees) for azimuth
+ *
+ * Note: The cube shows the scene from the camera's perspective, so the
+ * rotation is inverted — when camera theta increases (rotates left),
+ * the cube appears to rotate right.
+ */
+function cameraToCSS(theta: number, phi: number): string {
+  const thetaDeg = (theta * 180) / Math.PI;
+  const phiDeg = (phi * 180) / Math.PI;
+  return `rotateX(${phiDeg}deg) rotateZ(${thetaDeg}deg)`;
+}
+
+export function ViewCube() {
+  const cameraRef = useCameraRef();
+  const scheduleRender = useScheduleRender();
+
+  const cubeRef = useRef<HTMLDivElement>(null);
+  const cancelAnimationRef = useRef<(() => void) | null>(null);
+  const isDraggingRef = useRef(false);
+  const dragStartRef = useRef({ x: 0, y: 0 });
+  const rafIdRef = useRef<number | null>(null);
+
+  // Sync cube CSS transform to camera state on every animation frame
+  useEffect(() => {
+    function syncTransform(): void {
+      const camera = cameraRef.current;
+      const cube = cubeRef.current;
+      if (camera && cube) {
+        cube.style.transform = cameraToCSS(camera.theta, camera.phi);
+      }
+      rafIdRef.current = requestAnimationFrame(syncTransform);
+    }
+    rafIdRef.current = requestAnimationFrame(syncTransform);
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+      }
+    };
+  }, [cameraRef]);
+
+  // Navigate to a predefined view
+  const navigateTo = useCallback(
+    (view: ViewTarget) => {
+      const camera = cameraRef.current;
+      if (!camera) return;
+
+      // Cancel any in-progress animation
+      cancelAnimationRef.current?.();
+
+      cancelAnimationRef.current = animateCamera(
+        camera,
+        view,
+        ANIMATION_DURATION,
+        scheduleRender,
+        () => {
+          cancelAnimationRef.current = null;
+        }
+      );
+    },
+    [cameraRef, scheduleRender]
+  );
+
+  // Handle mouse down on the cube (start potential drag or click)
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      isDraggingRef.current = false;
+      dragStartRef.current = { x: event.clientX, y: event.clientY };
+
+      const handleMouseMove = (moveEvent: MouseEvent): void => {
+        const dx = moveEvent.clientX - dragStartRef.current.x;
+        const dy = moveEvent.clientY - dragStartRef.current.y;
+
+        if (!isDraggingRef.current && Math.sqrt(dx * dx + dy * dy) >= DRAG_THRESHOLD) {
+          isDraggingRef.current = true;
+          // Cancel any in-progress animation when drag starts
+          cancelAnimationRef.current?.();
+          cancelAnimationRef.current = null;
+          // Reset drag start to current position for smooth initial movement
+          dragStartRef.current = { x: moveEvent.clientX, y: moveEvent.clientY };
+          return;
+        }
+
+        if (!isDraggingRef.current) return;
+
+        const camera = cameraRef.current;
+        if (!camera) return;
+
+        const moveDx = moveEvent.clientX - dragStartRef.current.x;
+        const moveDy = moveEvent.clientY - dragStartRef.current.y;
+        dragStartRef.current = { x: moveEvent.clientX, y: moveEvent.clientY };
+
+        camera.theta -= moveDx * ORBIT_SENSITIVITY;
+        camera.phi = Math.max(
+          -Math.PI / 2 + POLE_MARGIN,
+          Math.min(Math.PI / 2 - POLE_MARGIN, camera.phi + moveDy * ORBIT_SENSITIVITY)
+        );
+        scheduleRender();
+      };
+
+      const handleMouseUp = (): void => {
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleMouseUp);
+      };
+
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+    },
+    [cameraRef, scheduleRender]
+  );
+
+  // Handle click on a face (only fires if not dragging)
+  const handleFaceClick = useCallback(
+    (faceName: string) => {
+      if (isDraggingRef.current) return;
+      const view = FACE_VIEWS[faceName];
+      if (view) navigateTo(view);
+    },
+    [navigateTo]
+  );
+
+  // Handle click on an edge (only fires if not dragging)
+  const handleEdgeClick = useCallback(
+    (edgeName: string) => {
+      if (isDraggingRef.current) return;
+      const view = EDGE_VIEWS[edgeName];
+      if (view) navigateTo(view);
+    },
+    [navigateTo]
+  );
+
+  // Cleanup animation on unmount
+  useEffect(() => {
+    return () => {
+      cancelAnimationRef.current?.();
+    };
+  }, []);
+
+  return (
+    <div id="view-cube-container" onMouseDown={handleMouseDown}>
+      <div id="view-cube" ref={cubeRef}>
+        {Object.keys(FACE_TRANSFORMS).map((name) => (
+          <div
+            key={name}
+            className="view-cube-face"
+            style={{ transform: FACE_TRANSFORMS[name] }}
+            onClick={() => handleFaceClick(name)}
+          >
+            {name.toUpperCase()}
+          </div>
+        ))}
+        {EDGE_DEFINITIONS.map((edge) => (
+          <div
+            key={edge.name}
+            className="view-cube-edge"
+            style={{
+              transform: edge.transform,
+              width: `${edge.width}px`,
+              height: `${edge.height}px`,
+            }}
+            onClick={() => handleEdgeClick(edge.name)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/webview/components/ViewCube.tsx
+++ b/src/webview/components/ViewCube.tsx
@@ -5,7 +5,7 @@ import { FACE_VIEWS, EDGE_VIEWS, ViewTarget } from '../viewCube/views';
 import { animateCamera } from '../viewCube/animation';
 
 /** Size of each cube face in CSS pixels. */
-const CUBE_SIZE = 80;
+const CUBE_SIZE = 64;
 
 /** Half the cube size — used for translateZ positioning. */
 const HALF = CUBE_SIZE / 2;

--- a/src/webview/components/ViewCube.tsx
+++ b/src/webview/components/ViewCube.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { useCameraRef, useScheduleRender } from '../context/VisualizerContext';
+import { useCameraRef, useScheduleRender, useAnimationCancel } from '../context/VisualizerContext';
 import { FACE_VIEWS, EDGE_VIEWS, ViewTarget } from '../viewCube/views';
 import { animateCamera } from '../viewCube/animation';
 
@@ -87,6 +87,7 @@ function cameraToCSS(theta: number, phi: number): string {
 export function ViewCube() {
   const cameraRef = useCameraRef();
   const scheduleRender = useScheduleRender();
+  const { registerAnimationCancel } = useAnimationCancel();
 
   const cubeRef = useRef<HTMLDivElement>(null);
   const cancelAnimationRef = useRef<(() => void) | null>(null);
@@ -121,17 +122,21 @@ export function ViewCube() {
       // Cancel any in-progress animation
       cancelAnimationRef.current?.();
 
-      cancelAnimationRef.current = animateCamera(
+      const cancel = animateCamera(
         camera,
         view,
         ANIMATION_DURATION,
         scheduleRender,
         () => {
           cancelAnimationRef.current = null;
+          registerAnimationCancel(null);
         }
       );
+
+      cancelAnimationRef.current = cancel;
+      registerAnimationCancel(cancel);
     },
-    [cameraRef, scheduleRender]
+    [cameraRef, scheduleRender, registerAnimationCancel]
   );
 
   // Handle mouse down on the cube (start potential drag or click)

--- a/src/webview/components/ViewCube.tsx
+++ b/src/webview/components/ViewCube.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useCameraRef, useScheduleRender, useAnimationCancel } from '../context/VisualizerContext';
+import { ORBIT_SENSITIVITY, POLE_MARGIN } from '../constants';
 import { FACE_VIEWS, EDGE_VIEWS, ViewTarget } from '../viewCube/views';
 import { animateCamera } from '../viewCube/animation';
 
@@ -12,14 +13,8 @@ const HALF = CUBE_SIZE / 2;
 /** Animation duration in milliseconds. */
 const ANIMATION_DURATION = 100;
 
-/** Orbit sensitivity in radians per pixel (matches interaction.ts). */
-const ORBIT_SENSITIVITY = 0.008;
-
 /** Minimum mouse movement in pixels to distinguish drag from click. */
 const DRAG_THRESHOLD = 3;
-
-/** Maximum phi to prevent gimbal lock (matches interaction.ts POLE_MARGIN). */
-const POLE_MARGIN = 0.01;
 
 /** CSS 3D transform for each face. */
 const FACE_TRANSFORMS: Record<string, string> = {
@@ -71,12 +66,13 @@ const EDGE_DEFINITIONS: readonly EdgeDefinition[] = [
  * - phi: elevation from XY plane
  *
  * CSS 3D uses Y-up by default, so we map:
- * - rotateX(-phi in degrees) for elevation
- * - rotateZ(-theta in degrees) for azimuth
+ * - rotateX(phi in degrees) for elevation
+ * - rotateZ(theta in degrees) for azimuth
  *
- * Note: The cube shows the scene from the camera's perspective, so the
- * rotation is inverted — when camera theta increases (rotates left),
- * the cube appears to rotate right.
+ * The signs are positive (not negated) because the cube represents the
+ * scene, not the camera — when the camera orbits right (theta decreases),
+ * the scene (and cube) appears to rotate left, which matches positive theta
+ * in CSS rotateZ.
  */
 function cameraToCSS(theta: number, phi: number): string {
   const thetaDeg = (theta * 180) / Math.PI;
@@ -95,12 +91,18 @@ export function ViewCube() {
   const dragStartRef = useRef({ x: 0, y: 0 });
   const rafIdRef = useRef<number | null>(null);
 
-  // Sync cube CSS transform to camera state on every animation frame
+  // Sync cube CSS transform to camera state on every animation frame.
+  // Dirty check avoids DOM writes when the camera is stationary.
   useEffect(() => {
+    let prevTheta = NaN;
+    let prevPhi = NaN;
+
     function syncTransform(): void {
       const camera = cameraRef.current;
       const cube = cubeRef.current;
-      if (camera && cube) {
+      if (camera && cube && (camera.theta !== prevTheta || camera.phi !== prevPhi)) {
+        prevTheta = camera.theta;
+        prevPhi = camera.phi;
         cube.style.transform = cameraToCSS(camera.theta, camera.phi);
       }
       rafIdRef.current = requestAnimationFrame(syncTransform);
@@ -213,8 +215,9 @@ export function ViewCube() {
   useEffect(() => {
     return () => {
       cancelAnimationRef.current?.();
+      registerAnimationCancel(null);
     };
-  }, []);
+  }, [registerAnimationCancel]);
 
   return (
     <div id="view-cube-container" onMouseDown={handleMouseDown}>
@@ -232,7 +235,7 @@ export function ViewCube() {
         {EDGE_DEFINITIONS.map((edge) => (
           <div
             key={edge.name}
-            className="view-cube-edge"
+            className={`view-cube-edge ${edge.width < edge.height ? 'view-cube-edge--vertical' : 'view-cube-edge--horizontal'}`}
             style={{
               transform: edge.transform,
               width: `${edge.width}px`,

--- a/src/webview/constants.ts
+++ b/src/webview/constants.ts
@@ -108,3 +108,11 @@ export const TOOL_TIP_OUTLINE_COLOR = '#1a1a1a';
 
 /** Tool tip dot outline width. */
 export const TOOL_TIP_OUTLINE_WIDTH = 1.5;
+
+// ── Shared interaction constants ─────────────────────────────────────
+
+/** Radians per pixel of mouse movement during orbit. */
+export const ORBIT_SENSITIVITY = 0.008;
+
+/** Margin in radians from the poles (+/- PI/2) to prevent gimbal lock. */
+export const POLE_MARGIN = 0.01;

--- a/src/webview/context/VisualizerContext.tsx
+++ b/src/webview/context/VisualizerContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useContext, useMemo, useReducer, useRef } from 'react';
 import { PathBounds, PathSegment, VisualizerConfig } from '../../visualizer/types';
+import { CameraState } from '../types';
 import { DEFAULT_ERROR_MESSAGE } from '../constants';
 import { useExtensionMessages } from '../hooks/useExtensionMessages';
 import { useSettings } from '../hooks/useSettings';
@@ -31,6 +32,8 @@ interface VisualizerActionsValue {
   readonly scheduleRender: () => void;
   /** Render immediately (synchronous). Use from within an existing rAF callback. */
   readonly renderNow: () => void;
+  readonly cameraRef: React.RefObject<CameraState | null>;
+  readonly registerCameraState: (camera: CameraState) => void;
   readonly updateMousePosition: (clientX: number, clientY: number) => void;
   readonly tooltip: {
     readonly onHoverChange: (index: number | null) => void;
@@ -55,6 +58,7 @@ export function VisualizerProvider({ children }: { readonly children: React.Reac
 
   const mousePositionRef = useRef({ x: 0, y: 0 });
   const cameraControlsRef = useRef<CameraControls | null>(null);
+  const cameraStateRef = useRef<CameraState | null>(null);
   const segmentsRef = useRef<PathSegment[]>(document.segments);
   segmentsRef.current = document.segments;
   const boundsRef = useRef<PathBounds | null>(document.bounds);
@@ -76,6 +80,10 @@ export function VisualizerProvider({ children }: { readonly children: React.Reac
 
   const registerCameraControls = useCallback((controls: CameraControls) => {
     cameraControlsRef.current = controls;
+  }, []);
+
+  const registerCameraState = useCallback((camera: CameraState) => {
+    cameraStateRef.current = camera;
   }, []);
 
   const resetView = useCallback(() => {
@@ -173,6 +181,8 @@ export function VisualizerProvider({ children }: { readonly children: React.Reac
       registerCameraControls,
       scheduleRender,
       renderNow,
+      cameraRef: cameraStateRef,
+      registerCameraState,
       updateMousePosition,
       tooltip: {
         onHoverChange,
@@ -189,6 +199,7 @@ export function VisualizerProvider({ children }: { readonly children: React.Reac
       registerCameraControls,
       scheduleRender,
       renderNow,
+      registerCameraState,
       updateMousePosition,
       onHoverChange,
       onCursorMove,
@@ -251,13 +262,19 @@ export function useTooltip(): {
   return { ...tooltip, ...actions };
 }
 
+/** Camera state ref for direct access (e.g. ViewCube sync). */
+export function useCameraRef(): React.RefObject<CameraState | null> {
+  return useVisualizerActions().cameraRef;
+}
+
 /** Camera control registration and reset. */
 export function useCameraControls(): {
   readonly registerCameraControls: (controls: CameraControls) => void;
+  readonly registerCameraState: (camera: CameraState) => void;
   readonly resetView: () => void;
 } {
-  const { registerCameraControls, resetView } = useVisualizerActions();
-  return { registerCameraControls, resetView };
+  const { registerCameraControls, registerCameraState, resetView } = useVisualizerActions();
+  return { registerCameraControls, registerCameraState, resetView };
 }
 
 /** Mouse position ref update (no re-renders). */

--- a/src/webview/context/VisualizerContext.tsx
+++ b/src/webview/context/VisualizerContext.tsx
@@ -34,6 +34,8 @@ interface VisualizerActionsValue {
   readonly renderNow: () => void;
   readonly cameraRef: React.RefObject<CameraState | null>;
   readonly registerCameraState: (camera: CameraState) => void;
+  readonly registerAnimationCancel: (cancel: (() => void) | null) => void;
+  readonly cancelAnimation: () => void;
   readonly updateMousePosition: (clientX: number, clientY: number) => void;
   readonly tooltip: {
     readonly onHoverChange: (index: number | null) => void;
@@ -84,6 +86,17 @@ export function VisualizerProvider({ children }: { readonly children: React.Reac
 
   const registerCameraState = useCallback((camera: CameraState) => {
     cameraStateRef.current = camera;
+  }, []);
+
+  const animationCancelRef = useRef<(() => void) | null>(null);
+
+  const registerAnimationCancel = useCallback((cancel: (() => void) | null) => {
+    animationCancelRef.current = cancel;
+  }, []);
+
+  const cancelAnimation = useCallback(() => {
+    animationCancelRef.current?.();
+    animationCancelRef.current = null;
   }, []);
 
   const resetView = useCallback(() => {
@@ -183,6 +196,8 @@ export function VisualizerProvider({ children }: { readonly children: React.Reac
       renderNow,
       cameraRef: cameraStateRef,
       registerCameraState,
+      registerAnimationCancel,
+      cancelAnimation,
       updateMousePosition,
       tooltip: {
         onHoverChange,
@@ -200,6 +215,8 @@ export function VisualizerProvider({ children }: { readonly children: React.Reac
       scheduleRender,
       renderNow,
       registerCameraState,
+      registerAnimationCancel,
+      cancelAnimation,
       updateMousePosition,
       onHoverChange,
       onCursorMove,
@@ -283,6 +300,19 @@ export function useMousePosition(): {
 } {
   const { updateMousePosition } = useVisualizerActions();
   return { updateMousePosition };
+}
+
+/** Register/unregister the active ViewCube animation cancel function. */
+export function useAnimationCancel(): {
+  readonly registerAnimationCancel: (cancel: (() => void) | null) => void;
+} {
+  const { registerAnimationCancel } = useVisualizerActions();
+  return { registerAnimationCancel };
+}
+
+/** Cancel any in-progress ViewCube animation. */
+export function useCancelAnimation(): () => void {
+  return useVisualizerActions().cancelAnimation;
 }
 
 /** Trigger a canvas re-render via the registered camera controls. */

--- a/src/webview/hooks/useCamera.ts
+++ b/src/webview/hooks/useCamera.ts
@@ -18,7 +18,8 @@ export interface UseCameraResult {
  */
 export function useCamera(
   canvasRef: React.RefObject<HTMLCanvasElement | null>,
-  onCameraChange: () => void
+  onCameraChange: () => void,
+  onDragStart?: () => void
 ): UseCameraResult {
   const cameraRef = useRef<CameraState>(createCameraState());
   const isDraggingRef = useRef<() => boolean>(() => false);
@@ -27,10 +28,10 @@ export function useCamera(
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const handle = setupInteraction(canvas, cameraRef.current, onCameraChange);
+    const handle = setupInteraction(canvas, cameraRef.current, onCameraChange, onDragStart);
     isDraggingRef.current = handle.isDragging;
     return () => handle.cleanup();
-  }, [canvasRef, onCameraChange]);
+  }, [canvasRef, onCameraChange, onDragStart]);
 
   const fitView = useCallback((segments: PathSegment[], bounds: PathBounds | null) => {
     if (segments.length === 0 || !bounds) return;

--- a/src/webview/interaction.ts
+++ b/src/webview/interaction.ts
@@ -9,6 +9,7 @@
  */
 
 import { CameraState, DragMode } from './types';
+import { ORBIT_SENSITIVITY, POLE_MARGIN } from './constants';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -30,9 +31,6 @@ export interface InteractionState {
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Radians per pixel of mouse movement during orbit. */
-const ORBIT_SENSITIVITY = 0.008;
-
 /** Zoom multiplier when scrolling down (zoom out). */
 const ZOOM_OUT_FACTOR = 1.12;
 
@@ -41,11 +39,6 @@ const ZOOM_IN_FACTOR = 0.89;
 
 /** Minimum orbit radius to prevent the camera from collapsing. */
 const MINIMUM_RADIUS = 0.01;
-
-/**
- * Margin in radians from the poles (+/- PI/2) to prevent gimbal lock.
- */
-const POLE_MARGIN = 0.01;
 
 /** CSS class applied to the canvas while dragging. */
 const DRAGGING_CLASS = 'dragging';

--- a/src/webview/interaction.ts
+++ b/src/webview/interaction.ts
@@ -66,7 +66,8 @@ const DRAGGING_CLASS = 'dragging';
 export function setupInteraction(
   canvas: HTMLCanvasElement,
   camera: CameraState,
-  onCameraChange: () => void
+  onCameraChange: () => void,
+  onDragStart?: () => void
 ): InteractionState {
   let dragMode: DragMode | null = null;
   let lastMouseX = 0;
@@ -81,6 +82,7 @@ export function setupInteraction(
     lastMouseX = event.clientX;
     lastMouseY = event.clientY;
     canvas.classList.add(DRAGGING_CLASS);
+    onDragStart?.();
     event.preventDefault();
   }
 

--- a/src/webview/styles.scss
+++ b/src/webview/styles.scss
@@ -509,8 +509,7 @@ $cube-half: 40px;
     transition: all 0.1s;
   }
 
-  // For vertical edges (width = EDGE_SIZE, height = EDGE_LENGTH)
-  &[style*='width: 12px'] {
+  &--vertical {
     &::after {
       width: 1px;
       height: 100%;
@@ -522,8 +521,7 @@ $cube-half: 40px;
     }
   }
 
-  // For horizontal edges (width = EDGE_LENGTH, height = EDGE_SIZE)
-  &[style*='height: 12px'] {
+  &--horizontal {
     &::after {
       width: 100%;
       height: 1px;

--- a/src/webview/styles.scss
+++ b/src/webview/styles.scss
@@ -434,3 +434,128 @@ $font-size: var(--vscode-editor-font-size, 12px);
   cursor: pointer;
   accent-color: var(--vscode-progressBar-background, #0e70c0);
 }
+
+// ── ViewCube navigation gizmo ──────────────────────────────────────
+
+$cube-size: 80px;
+$cube-half: 40px;
+
+#view-cube-container {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 120px;
+  height: 120px;
+  z-index: 4;
+  perspective: 300px;
+  perspective-origin: 50% 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  cursor: grab;
+  user-select: none;
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+#view-cube {
+  width: $cube-size;
+  height: $cube-size;
+  position: relative;
+  transform-style: preserve-3d;
+}
+
+.view-cube-face {
+  position: absolute;
+  width: $cube-size;
+  height: $cube-size;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backface-visibility: hidden;
+
+  background: rgba(60, 63, 70, 0.85);
+  border: 1px solid rgba(150, 150, 150, 0.3);
+  color: rgba(200, 200, 200, 0.8);
+  font: bold 10px var(--vscode-font-family, 'Segoe UI', sans-serif);
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  transition: background 0.1s;
+
+  &:hover {
+    background: rgba(80, 83, 92, 0.9);
+    color: rgba(230, 230, 230, 1);
+  }
+}
+
+.view-cube-edge {
+  position: absolute;
+  backface-visibility: hidden;
+  cursor: pointer;
+
+  // Visible line: centered 1px strip
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &::after {
+    content: '';
+    position: absolute;
+    background: rgba(150, 150, 150, 0.4);
+    transition: all 0.1s;
+  }
+
+  // For vertical edges (width = EDGE_SIZE, height = EDGE_LENGTH)
+  &[style*='width: 12px'] {
+    &::after {
+      width: 1px;
+      height: 100%;
+    }
+
+    &:hover::after {
+      width: 2px;
+      background: rgba(180, 180, 180, 0.7);
+    }
+  }
+
+  // For horizontal edges (width = EDGE_LENGTH, height = EDGE_SIZE)
+  &[style*='height: 12px'] {
+    &::after {
+      width: 100%;
+      height: 1px;
+    }
+
+    &:hover::after {
+      height: 2px;
+      background: rgba(180, 180, 180, 0.7);
+    }
+  }
+}
+
+// Light theme overrides
+.vscode-light {
+  .view-cube-face {
+    background: rgba(220, 222, 228, 0.85);
+    border-color: rgba(100, 100, 100, 0.3);
+    color: rgba(60, 60, 60, 0.8);
+
+    &:hover {
+      background: rgba(200, 202, 210, 0.9);
+      color: rgba(30, 30, 30, 1);
+    }
+  }
+
+  .view-cube-edge {
+    &::after {
+      background: rgba(100, 100, 100, 0.4);
+    }
+
+    &:hover::after {
+      background: rgba(80, 80, 80, 0.7);
+    }
+  }
+}

--- a/src/webview/styles.scss
+++ b/src/webview/styles.scss
@@ -501,6 +501,8 @@ $cube-half: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
+  left: 50%;
+  top: 50%;
 
   &::after {
     content: '';

--- a/src/webview/styles.scss
+++ b/src/webview/styles.scss
@@ -437,15 +437,15 @@ $font-size: var(--vscode-editor-font-size, 12px);
 
 // ── ViewCube navigation gizmo ──────────────────────────────────────
 
-$cube-size: 80px;
-$cube-half: 40px;
+$cube-size: 64px;
+$cube-half: 32px;
 
 #view-cube-container {
   position: absolute;
-  top: 12px;
-  right: 12px;
-  width: 120px;
-  height: 120px;
+  top: 24px;
+  right: 24px;
+  width: 100px;
+  height: 100px;
   z-index: 4;
   perspective: 300px;
   perspective-origin: 50% 50%;

--- a/src/webview/viewCube/animation.ts
+++ b/src/webview/viewCube/animation.ts
@@ -54,6 +54,7 @@ export function animateCamera(
   const deltaTheta = normalizeAngle(target.theta - startTheta);
   const deltaPhi = target.phi - startPhi;
 
+  let rafId: number | null = null;
   let cancelled = false;
   let startTime: number | null = null;
 
@@ -73,8 +74,9 @@ export function animateCamera(
     onFrame();
 
     if (progress < 1) {
-      requestAnimationFrame(step);
+      rafId = requestAnimationFrame(step);
     } else {
+      rafId = null;
       // Snap to exact target
       camera.theta = target.theta;
       camera.phi = target.phi;
@@ -83,9 +85,13 @@ export function animateCamera(
     }
   }
 
-  requestAnimationFrame(step);
+  rafId = requestAnimationFrame(step);
 
   return () => {
     cancelled = true;
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
   };
 }

--- a/src/webview/viewCube/animation.ts
+++ b/src/webview/viewCube/animation.ts
@@ -40,6 +40,15 @@ export function animateCamera(
   onFrame: () => void,
   onComplete?: () => void
 ): () => void {
+  // Guard: instant snap for zero or negative duration
+  if (duration <= 0) {
+    camera.theta = target.theta;
+    camera.phi = target.phi;
+    onFrame();
+    onComplete?.();
+    return () => {};
+  }
+
   const startTheta = camera.theta;
   const startPhi = camera.phi;
   const deltaTheta = normalizeAngle(target.theta - startTheta);

--- a/src/webview/viewCube/animation.ts
+++ b/src/webview/viewCube/animation.ts
@@ -1,0 +1,82 @@
+import { CameraState } from '../types';
+
+/**
+ * Normalize an angular delta to the range [-PI, PI] for shortest-path interpolation.
+ */
+export function normalizeAngle(delta: number): number {
+  let normalized = delta % (2 * Math.PI);
+  if (normalized > Math.PI) {
+    normalized -= 2 * Math.PI;
+  } else if (normalized < -Math.PI) {
+    normalized += 2 * Math.PI;
+  }
+  return normalized;
+}
+
+/**
+ * Ease-out quadratic: fast start, gradual deceleration.
+ */
+function easeOut(t: number): number {
+  return 1 - (1 - t) * (1 - t);
+}
+
+/**
+ * Smoothly animates the camera from its current theta/phi to the target values.
+ *
+ * Mutates the camera state in place on each frame and calls `onFrame` to
+ * trigger a canvas re-render. Uses shortest angular path for theta.
+ *
+ * @param camera     - The mutable camera state object
+ * @param target     - Destination angles `{ theta, phi }`
+ * @param duration   - Animation duration in milliseconds
+ * @param onFrame    - Called each frame to trigger re-render (e.g. `scheduleRender`)
+ * @param onComplete - Optional callback when animation finishes
+ * @returns A cancel function that stops the animation
+ */
+export function animateCamera(
+  camera: CameraState,
+  target: { readonly theta: number; readonly phi: number },
+  duration: number,
+  onFrame: () => void,
+  onComplete?: () => void
+): () => void {
+  const startTheta = camera.theta;
+  const startPhi = camera.phi;
+  const deltaTheta = normalizeAngle(target.theta - startTheta);
+  const deltaPhi = target.phi - startPhi;
+
+  let cancelled = false;
+  let startTime: number | null = null;
+
+  function step(timestamp: number): void {
+    if (cancelled) return;
+
+    if (startTime === null) {
+      startTime = timestamp;
+    }
+
+    const elapsed = timestamp - startTime;
+    const progress = Math.min(elapsed / duration, 1);
+    const eased = easeOut(progress);
+
+    camera.theta = startTheta + deltaTheta * eased;
+    camera.phi = startPhi + deltaPhi * eased;
+    onFrame();
+
+    if (progress < 1) {
+      requestAnimationFrame(step);
+    } else {
+      // Snap to exact target
+      camera.theta = target.theta;
+      camera.phi = target.phi;
+      onFrame();
+      onComplete?.();
+    }
+  }
+
+  requestAnimationFrame(step);
+
+  return () => {
+    cancelled = true;
+  };
+}

--- a/src/webview/viewCube/views.ts
+++ b/src/webview/viewCube/views.ts
@@ -1,3 +1,5 @@
+import { POLE_MARGIN } from '../constants';
+
 /**
  * Target camera angles for a predefined view.
  */
@@ -5,8 +7,6 @@ export interface ViewTarget {
   readonly theta: number;
   readonly phi: number;
 }
-
-import { POLE_MARGIN } from '../constants';
 
 /**
  * Camera angles for the 6 face views (orthographic axes).

--- a/src/webview/viewCube/views.ts
+++ b/src/webview/viewCube/views.ts
@@ -1,0 +1,40 @@
+/**
+ * Target camera angles for a predefined view.
+ */
+export interface ViewTarget {
+  readonly theta: number;
+  readonly phi: number;
+}
+
+/** Pole margin matching the interaction module's POLE_MARGIN. */
+const POLE_MARGIN = 0.01;
+
+/**
+ * Camera angles for the 6 face views (orthographic axes).
+ */
+export const FACE_VIEWS: Readonly<Record<string, ViewTarget>> = {
+  Front: { theta: 0, phi: 0 },
+  Back: { theta: Math.PI, phi: 0 },
+  Right: { theta: -Math.PI / 2, phi: 0 },
+  Left: { theta: Math.PI / 2, phi: 0 },
+  Top: { theta: 0, phi: Math.PI / 2 - POLE_MARGIN },
+  Bottom: { theta: 0, phi: -Math.PI / 2 + POLE_MARGIN },
+} as const;
+
+/**
+ * Camera angles for the 12 edge views (midpoint between adjacent faces).
+ */
+export const EDGE_VIEWS: Readonly<Record<string, ViewTarget>> = {
+  'Front-Top': { theta: 0, phi: Math.PI / 4 },
+  'Front-Bottom': { theta: 0, phi: -Math.PI / 4 },
+  'Front-Right': { theta: -Math.PI / 4, phi: 0 },
+  'Front-Left': { theta: Math.PI / 4, phi: 0 },
+  'Back-Top': { theta: Math.PI, phi: Math.PI / 4 },
+  'Back-Bottom': { theta: Math.PI, phi: -Math.PI / 4 },
+  'Back-Right': { theta: (-3 * Math.PI) / 4, phi: 0 },
+  'Back-Left': { theta: (3 * Math.PI) / 4, phi: 0 },
+  'Right-Top': { theta: -Math.PI / 2, phi: Math.PI / 4 },
+  'Right-Bottom': { theta: -Math.PI / 2, phi: -Math.PI / 4 },
+  'Left-Top': { theta: Math.PI / 2, phi: Math.PI / 4 },
+  'Left-Bottom': { theta: Math.PI / 2, phi: -Math.PI / 4 },
+} as const;

--- a/src/webview/viewCube/views.ts
+++ b/src/webview/viewCube/views.ts
@@ -6,8 +6,7 @@ export interface ViewTarget {
   readonly phi: number;
 }
 
-/** Pole margin matching the interaction module's POLE_MARGIN. */
-const POLE_MARGIN = 0.01;
+import { POLE_MARGIN } from '../constants';
 
 /**
  * Camera angles for the 6 face views (orthographic axes).


### PR DESCRIPTION
## Summary

- Add a CSS 3D navigation cube (ViewCube) in the top-right corner of the visualizer for quick camera view selection
- 18 click targets: 6 faces (Top/Bottom/Front/Back/Left/Right) + 12 edges (diagonal views like Front-Top, Front-Right)
- Drag-to-orbit on the cube mirrors main canvas orbit behavior
- 100ms ease-out animated transitions with shortest angular path
- Bidirectional sync: orbiting the canvas rotates the cube, clicking/dragging the cube controls the camera
- Animation cancellation: starting a canvas drag or new cube click cancels any in-progress animation
- Dark and light theme support via VS Code CSS variables

Closes #121

## Architecture

```
ViewCube.tsx          — CSS 3D cube component, click/drag handlers, camera sync
├── viewCube/views.ts     — 18 view angle definitions (face/edge → theta/phi)
├── viewCube/animation.ts — animateCamera() with shortest-path interpolation
├── constants.ts          — shared ORBIT_SENSITIVITY, POLE_MARGIN
├── context/VisualizerContext.tsx — camera ref + animation cancel hooks
└── styles.scss           — positioning, face/edge appearance, theme overrides
```

## Manual testing

1. Open a `.nc` file with the 3D visualizer
2. Verify the cube appears in the top-right corner (64px, 24px from edges)
3. Orbit the main canvas — cube should rotate in sync
4. Click "FRONT" face — camera snaps to front orthographic view
5. Click "TOP" face — camera snaps to top-down view
6. Click an edge between faces — camera snaps to 45° diagonal view
7. Drag the cube — main canvas orbits in response
8. Click a face mid-orbit — animation should cancel any in-progress drag smoothly
9. Hover a face — it brightens; hover an edge — line thickens from 1px to 2px
10. Switch to a light VS Code theme — cube colors adapt
11. Verify existing interactions still work: path hover tooltip, playback, click-to-navigate