### PR TITLE
feat: add workspace symbol search (Ctrl+T)

### DIFF
--- a/package.json
+++ b/package.json
@@ -376,6 +376,18 @@
           "additionalProperties": {
             "type": "number"
           }
+        },
+        "gcode.workspace.indexingEnabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable workspace-wide symbol indexing for Ctrl+T search across all G-code files"
+        },
+        "gcode.workspace.maxSymbols": {
+          "type": "integer",
+          "default": 10000,
+          "minimum": 100,
+          "maximum": 100000,
+          "description": "Maximum number of symbols to index across all workspace files"
         }
       }
     }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -56,4 +56,9 @@ export const DEFAULT_GCODE_CONFIG: GCodeConfig = {
   },
 
   variables: {},
+
+  workspace: {
+    indexingEnabled: true,
+    maxSymbols: 10_000,
+  },
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -16,6 +16,16 @@ import {
 } from '../visualizer/types';
 
 /**
+ * Workspace-level configuration for symbol indexing.
+ */
+export interface WorkspaceConfig {
+  /** Whether workspace-wide symbol indexing is enabled. */
+  readonly indexingEnabled: boolean;
+  /** Maximum number of symbols to index across all workspace files. */
+  readonly maxSymbols: number;
+}
+
+/**
  * Root configuration for the entire G-code extension.
  */
 export interface GCodeConfig {
@@ -31,6 +41,8 @@ export interface GCodeConfig {
   readonly interpreter: InterpreterConfig;
   /** User-defined global variable values. */
   readonly variables: VariableDefinitions;
+  /** Workspace settings (symbol indexing). */
+  readonly workspace: WorkspaceConfig;
 }
 
 /**

--- a/src/e2e/suite/workspaceSymbol.test.ts
+++ b/src/e2e/suite/workspaceSymbol.test.ts
@@ -1,0 +1,79 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { TestUtils } from '../testUtils';
+
+suite('Workspace Symbol Tests', () => {
+  TestUtils.setup();
+
+  test('Should find subroutine definitions via workspace symbols', async () => {
+    await TestUtils.createGCodeDocument('O100 SUB\nG0 X10\nO100 ENDSUB', 'ws-symbol-sub.nc');
+
+    // Wait for the language server to index the document
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+      'vscode.executeWorkspaceSymbolProvider',
+      'O100'
+    );
+
+    assert.ok(Array.isArray(symbols), 'Should return array of symbols');
+    const matching = symbols.filter((s) => s.name === 'O100');
+    assert.ok(matching.length > 0, 'Should find O100 subroutine definition');
+  });
+
+  test('Should find variables via workspace symbols', async () => {
+    await TestUtils.createGCodeDocument('#<feed> = 100\n#<speed> = 500', 'ws-symbol-var.nc');
+
+    // Wait for the language server to index the document
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+      'vscode.executeWorkspaceSymbolProvider',
+      'feed'
+    );
+
+    assert.ok(Array.isArray(symbols), 'Should return array of symbols');
+    const matching = symbols.filter((s) => s.name.includes('feed'));
+    assert.ok(matching.length > 0, 'Should find feed variable');
+  });
+
+  test('Should return empty array for non-matching query', async () => {
+    const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+      'vscode.executeWorkspaceSymbolProvider',
+      'NONEXISTENT_SYMBOL_12345'
+    );
+
+    assert.ok(
+      Array.isArray(symbols) || symbols === undefined,
+      'Should return array or undefined for non-matching query'
+    );
+    if (Array.isArray(symbols)) {
+      const matching = symbols.filter((s) => s.name.includes('NONEXISTENT_SYMBOL_12345'));
+      assert.strictEqual(matching.length, 0, 'Should find no matching symbols');
+    }
+  });
+
+  test('Should find symbols with partial match', async () => {
+    await TestUtils.createGCodeDocument('O500 SUB\nG0 X10\nO500 ENDSUB', 'ws-symbol-partial.nc');
+
+    // Wait for the language server to index the document
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+      'vscode.executeWorkspaceSymbolProvider',
+      'O5'
+    );
+
+    assert.ok(Array.isArray(symbols), 'Should return array of symbols');
+    const matching = symbols.filter((s) => s.name.includes('O5'));
+    assert.ok(matching.length > 0, 'Should find symbols matching partial query O5');
+  });
+
+  suiteTeardown(async () => {
+    TestUtils.deleteTestFileByName('ws-symbol-sub.nc');
+    TestUtils.deleteTestFileByName('ws-symbol-var.nc');
+    TestUtils.deleteTestFileByName('ws-symbol-partial.nc');
+    await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+  });
+});

--- a/src/e2e/suite/workspaceSymbol.test.ts
+++ b/src/e2e/suite/workspaceSymbol.test.ts
@@ -43,19 +43,18 @@ suite('Workspace Symbol Tests', () => {
   });
 
   test('Should return empty array for non-matching query', async () => {
-    const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
-      'vscode.executeWorkspaceSymbolProvider',
-      'NONEXISTENT_SYMBOL_12345'
+    const symbols = await TestUtils.waitForCondition(
+      async () =>
+        vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+          'vscode.executeWorkspaceSymbolProvider',
+          'NONEXISTENT_SYMBOL_12345'
+        ),
+      (result) => Array.isArray(result)
     );
 
-    assert.ok(
-      Array.isArray(symbols) || symbols === undefined,
-      'Should return array or undefined for non-matching query'
-    );
-    if (Array.isArray(symbols)) {
-      const matching = symbols.filter((s) => s.name.includes('NONEXISTENT_SYMBOL_12345'));
-      assert.strictEqual(matching.length, 0, 'Should find no matching symbols');
-    }
+    assert.ok(Array.isArray(symbols), 'Should return array');
+    const matching = symbols.filter((s) => s.name.includes('NONEXISTENT_SYMBOL_12345'));
+    assert.strictEqual(matching.length, 0, 'Should find no matching symbols');
   });
 
   test('Should find symbols with partial match', async () => {

--- a/src/e2e/suite/workspaceSymbol.test.ts
+++ b/src/e2e/suite/workspaceSymbol.test.ts
@@ -9,12 +9,14 @@ suite('Workspace Symbol Tests', () => {
   test('Should find subroutine definitions via workspace symbols', async () => {
     await TestUtils.createGCodeDocument('O100 SUB\nG0 X10\nO100 ENDSUB', 'ws-symbol-sub.nc');
 
-    // Wait for the language server to index the document
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-
-    const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
-      'vscode.executeWorkspaceSymbolProvider',
-      'O100'
+    // Poll until the language server has indexed the document
+    const symbols = await TestUtils.waitForCondition(
+      async () =>
+        vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+          'vscode.executeWorkspaceSymbolProvider',
+          'O100'
+        ),
+      (result) => Array.isArray(result) && result.some((s) => s.name === 'O100')
     );
 
     assert.ok(Array.isArray(symbols), 'Should return array of symbols');
@@ -25,12 +27,14 @@ suite('Workspace Symbol Tests', () => {
   test('Should find variables via workspace symbols', async () => {
     await TestUtils.createGCodeDocument('#<feed> = 100\n#<speed> = 500', 'ws-symbol-var.nc');
 
-    // Wait for the language server to index the document
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-
-    const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
-      'vscode.executeWorkspaceSymbolProvider',
-      'feed'
+    // Poll until the language server has indexed the document
+    const symbols = await TestUtils.waitForCondition(
+      async () =>
+        vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+          'vscode.executeWorkspaceSymbolProvider',
+          'feed'
+        ),
+      (result) => Array.isArray(result) && result.some((s) => s.name.includes('feed'))
     );
 
     assert.ok(Array.isArray(symbols), 'Should return array of symbols');
@@ -57,12 +61,14 @@ suite('Workspace Symbol Tests', () => {
   test('Should find symbols with partial match', async () => {
     await TestUtils.createGCodeDocument('O500 SUB\nG0 X10\nO500 ENDSUB', 'ws-symbol-partial.nc');
 
-    // Wait for the language server to index the document
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-
-    const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
-      'vscode.executeWorkspaceSymbolProvider',
-      'O5'
+    // Poll until the language server has indexed the document
+    const symbols = await TestUtils.waitForCondition(
+      async () =>
+        vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+          'vscode.executeWorkspaceSymbolProvider',
+          'O5'
+        ),
+      (result) => Array.isArray(result) && result.some((s) => s.name.includes('O5'))
     );
 
     assert.ok(Array.isArray(symbols), 'Should return array of symbols');

--- a/src/e2e/testUtils.ts
+++ b/src/e2e/testUtils.ts
@@ -257,6 +257,38 @@ export class TestUtils {
   }
 
   /**
+   * Poll until a condition returns a truthy value, or throw on timeout.
+   *
+   * Useful for waiting on language server indexing or other async server
+   * behaviour instead of a hard-coded `setTimeout`.
+   *
+   * @param fn       - Async function that returns the result to check.
+   * @param check    - Predicate applied to the result — polling stops when it returns `true`.
+   * @param timeout  - Maximum time in milliseconds before giving up.
+   * @param interval - Polling interval in milliseconds.
+   * @returns The first result for which `check` returned `true`.
+   */
+  static async waitForCondition<T>(
+    fn: () => Promise<T>,
+    check: (result: T) => boolean,
+    timeout: number = 10000,
+    interval: number = 250
+  ): Promise<T> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeout) {
+      const result = await fn();
+      if (check(result)) {
+        return result;
+      }
+      await this.sleep(interval);
+    }
+
+    // Run one last time and return whatever we get
+    return fn();
+  }
+
+  /**
    * Wait for a specific amount of time
    */
   private static async sleep(ms: number): Promise<void> {

--- a/src/e2e/testUtils.ts
+++ b/src/e2e/testUtils.ts
@@ -284,8 +284,12 @@ export class TestUtils {
       await this.sleep(interval);
     }
 
-    // Run one last time and return whatever we get
-    return fn();
+    // Run one last time and check condition — throw if still not met
+    const finalResult = await fn();
+    if (!check(finalResult)) {
+      throw new Error(`waitForCondition timed out after ${timeout}ms`);
+    }
+    return finalResult;
   }
 
   /**

--- a/src/providers/WorkspaceSymbolIndex.ts
+++ b/src/providers/WorkspaceSymbolIndex.ts
@@ -1,0 +1,193 @@
+/**
+ * Workspace Symbol Index
+ *
+ * Maintains an in-memory index of symbols across all G-code files
+ * in the workspace. Supports fuzzy matching for workspace symbol search.
+ *
+ * Uses the existing lexer/parser pipeline to extract symbols from files
+ * via the WorkspaceSymbolVisitor.
+ */
+import { DialectType } from '../constants';
+import { LexerFactory } from '../lexer/LexerFactory';
+import { AstTraverser } from '../parser/AstTraverser';
+import { ParserFactory } from '../parser/ParserFactory';
+import { WorkspaceSymbol, WorkspaceSymbolVisitor } from './WorkspaceSymbolVisitor';
+
+/** Default maximum number of symbols to return from a search query. */
+const DEFAULT_MAX_RESULTS = 100;
+
+/** Default maximum number of symbols to index across the workspace. */
+const DEFAULT_MAX_SYMBOLS = 10000;
+
+/**
+ * Configuration for the workspace symbol index.
+ */
+export interface WorkspaceSymbolIndexConfig {
+  /** Whether workspace indexing is enabled. */
+  readonly indexingEnabled: boolean;
+  /** Maximum number of symbols to index across all files. */
+  readonly maxSymbols: number;
+}
+
+/**
+ * In-memory index of workspace symbols.
+ *
+ * Stores symbols per file URI. When a file changes, its entry is
+ * invalidated and rebuilt from the new content on the next indexing pass.
+ * Supports fuzzy (substring) matching for workspace symbol queries.
+ */
+export class WorkspaceSymbolIndex {
+  /** Symbols indexed per file URI. */
+  private readonly fileSymbols = new Map<string, readonly WorkspaceSymbol[]>();
+
+  /** Total number of symbols currently indexed. */
+  private totalSymbolCount = 0;
+
+  /** Maximum symbols to store across all files. */
+  private maxSymbols: number;
+
+  constructor(maxSymbols: number = DEFAULT_MAX_SYMBOLS) {
+    this.maxSymbols = maxSymbols;
+  }
+
+  /**
+   * Update the maximum symbols limit.
+   */
+  setMaxSymbols(maxSymbols: number): void {
+    this.maxSymbols = maxSymbols;
+  }
+
+  /**
+   * Index a single file by parsing its content and extracting symbols.
+   *
+   * @param uri     - File URI
+   * @param content - File text content
+   * @param dialect - G-code dialect to use for parsing
+   */
+  indexFile(uri: string, content: string, dialect: DialectType = DialectType.LINUXCNC): void {
+    // Remove existing symbols for this file first
+    this.removeFile(uri);
+
+    // Check if we've hit the global limit
+    if (this.totalSymbolCount >= this.maxSymbols) {
+      return;
+    }
+
+    const symbols = this.extractSymbols(uri, content, dialect);
+
+    // Clamp to remaining capacity
+    const remaining = this.maxSymbols - this.totalSymbolCount;
+    const trimmedSymbols = symbols.length > remaining ? symbols.slice(0, remaining) : symbols;
+
+    this.fileSymbols.set(uri, trimmedSymbols);
+    this.totalSymbolCount += trimmedSymbols.length;
+  }
+
+  /**
+   * Remove all indexed symbols for a file.
+   *
+   * @param uri - File URI to remove
+   */
+  removeFile(uri: string): void {
+    const existing = this.fileSymbols.get(uri);
+    if (existing) {
+      this.totalSymbolCount -= existing.length;
+      this.fileSymbols.delete(uri);
+    }
+  }
+
+  /**
+   * Check whether a file is currently indexed.
+   */
+  hasFile(uri: string): boolean {
+    return this.fileSymbols.has(uri);
+  }
+
+  /**
+   * Search the index for symbols matching a query string.
+   *
+   * Uses case-insensitive substring matching. An empty query returns
+   * all indexed symbols (up to maxResults).
+   *
+   * @param query      - Search query (empty string = all symbols)
+   * @param maxResults - Maximum number of results to return
+   * @returns Matching symbols, sorted by relevance (prefix > substring)
+   */
+  search(query: string, maxResults: number = DEFAULT_MAX_RESULTS): readonly WorkspaceSymbol[] {
+    const normalizedQuery = query.toLowerCase();
+    const matches: WorkspaceSymbol[] = [];
+
+    for (const symbols of this.fileSymbols.values()) {
+      for (const symbol of symbols) {
+        if (normalizedQuery === '' || symbol.name.toLowerCase().includes(normalizedQuery)) {
+          matches.push(symbol);
+        }
+      }
+    }
+
+    // Sort by relevance: prefix matches first, then alphabetical
+    if (normalizedQuery !== '') {
+      matches.sort((first, second) => {
+        const firstStartsWith = first.name.toLowerCase().startsWith(normalizedQuery);
+        const secondStartsWith = second.name.toLowerCase().startsWith(normalizedQuery);
+
+        if (firstStartsWith && !secondStartsWith) return -1;
+        if (!firstStartsWith && secondStartsWith) return 1;
+
+        // Within the same category, sort alphabetically
+        return first.name.localeCompare(second.name);
+      });
+    }
+
+    return matches.slice(0, maxResults);
+  }
+
+  /**
+   * Get the total number of indexed symbols.
+   */
+  getSymbolCount(): number {
+    return this.totalSymbolCount;
+  }
+
+  /**
+   * Get the number of indexed files.
+   */
+  getFileCount(): number {
+    return this.fileSymbols.size;
+  }
+
+  /**
+   * Get all symbols for a specific file.
+   */
+  getFileSymbols(uri: string): readonly WorkspaceSymbol[] {
+    return this.fileSymbols.get(uri) ?? [];
+  }
+
+  /**
+   * Clear the entire index.
+   */
+  clear(): void {
+    this.fileSymbols.clear();
+    this.totalSymbolCount = 0;
+  }
+
+  /**
+   * Extract symbols from file content using the lexer/parser pipeline.
+   */
+  private extractSymbols(
+    uri: string,
+    content: string,
+    dialect: DialectType
+  ): readonly WorkspaceSymbol[] {
+    const lexer = LexerFactory.create(dialect);
+    const tokens = lexer.tokenize(content);
+    const parser = ParserFactory.create(dialect, tokens, content);
+    const ast = parser.parseProgram();
+
+    const visitor = new WorkspaceSymbolVisitor(uri);
+    const traverser = new AstTraverser(visitor);
+    traverser.traverseProgram(ast);
+
+    return visitor.getSymbols();
+  }
+}

--- a/src/providers/WorkspaceSymbolIndex.ts
+++ b/src/providers/WorkspaceSymbolIndex.ts
@@ -14,7 +14,7 @@ import { ParserFactory } from '../parser/ParserFactory';
 import { WorkspaceSymbol, WorkspaceSymbolVisitor } from './WorkspaceSymbolVisitor';
 
 /** Default maximum number of symbols to return from a search query. */
-const DEFAULT_MAX_RESULTS = 100;
+export const DEFAULT_MAX_RESULTS = 100;
 
 /** Default maximum number of symbols to index across the workspace. */
 const DEFAULT_MAX_SYMBOLS = 10000;

--- a/src/providers/WorkspaceSymbolIndex.ts
+++ b/src/providers/WorkspaceSymbolIndex.ts
@@ -8,26 +8,11 @@
  * via the WorkspaceSymbolVisitor.
  */
 import { DialectType } from '../constants';
+import { DEFAULT_GCODE_CONFIG } from '../config/defaults';
 import { LexerFactory } from '../lexer/LexerFactory';
 import { AstTraverser } from '../parser/AstTraverser';
 import { ParserFactory } from '../parser/ParserFactory';
 import { WorkspaceSymbol, WorkspaceSymbolVisitor } from './WorkspaceSymbolVisitor';
-
-/** Default maximum number of symbols to return from a search query. */
-export const DEFAULT_MAX_RESULTS = 100;
-
-/** Default maximum number of symbols to index across the workspace. */
-const DEFAULT_MAX_SYMBOLS = 10000;
-
-/**
- * Configuration for the workspace symbol index.
- */
-export interface WorkspaceSymbolIndexConfig {
-  /** Whether workspace indexing is enabled. */
-  readonly indexingEnabled: boolean;
-  /** Maximum number of symbols to index across all files. */
-  readonly maxSymbols: number;
-}
 
 /**
  * In-memory index of workspace symbols.
@@ -46,7 +31,7 @@ export class WorkspaceSymbolIndex {
   /** Maximum symbols to store across all files. */
   private maxSymbols: number;
 
-  constructor(maxSymbols: number = DEFAULT_MAX_SYMBOLS) {
+  constructor(maxSymbols: number = DEFAULT_GCODE_CONFIG.workspace.maxSymbols) {
     this.maxSymbols = maxSymbols;
   }
 
@@ -113,7 +98,7 @@ export class WorkspaceSymbolIndex {
    * @param maxResults - Maximum number of results to return
    * @returns Matching symbols, sorted by relevance (prefix > substring)
    */
-  search(query: string, maxResults: number = DEFAULT_MAX_RESULTS): readonly WorkspaceSymbol[] {
+  search(query: string, maxResults = 100): readonly WorkspaceSymbol[] {
     const normalizedQuery = query.toLowerCase();
     const matches: WorkspaceSymbol[] = [];
 
@@ -179,15 +164,19 @@ export class WorkspaceSymbolIndex {
     content: string,
     dialect: DialectType
   ): readonly WorkspaceSymbol[] {
-    const lexer = LexerFactory.create(dialect);
-    const tokens = lexer.tokenize(content);
-    const parser = ParserFactory.create(dialect, tokens, content);
-    const ast = parser.parseProgram();
+    try {
+      const lexer = LexerFactory.create(dialect);
+      const tokens = lexer.tokenize(content);
+      const parser = ParserFactory.create(dialect, tokens, content);
+      const ast = parser.parseProgram();
 
-    const visitor = new WorkspaceSymbolVisitor(uri);
-    const traverser = new AstTraverser(visitor);
-    traverser.traverseProgram(ast);
+      const visitor = new WorkspaceSymbolVisitor(uri);
+      const traverser = new AstTraverser(visitor);
+      traverser.traverseProgram(ast);
 
-    return visitor.getSymbols();
+      return visitor.getSymbols();
+    } catch {
+      return [];
+    }
   }
 }

--- a/src/providers/WorkspaceSymbolProvider.ts
+++ b/src/providers/WorkspaceSymbolProvider.ts
@@ -1,0 +1,40 @@
+/**
+ * Workspace Symbol Provider
+ *
+ * Implements the LSP workspace symbol handler. Queries the
+ * WorkspaceSymbolIndex and returns SymbolInformation results
+ * for the workspace symbol search (Ctrl+T).
+ */
+import { SymbolInformation } from 'vscode-languageserver/node';
+
+import { WorkspaceSymbolIndex } from './WorkspaceSymbolIndex';
+
+/** Default maximum number of results to return from a workspace symbol search. */
+const DEFAULT_MAX_RESULTS = 100;
+
+/**
+ * Provider for LSP `workspace/symbol` requests.
+ *
+ * Delegates to a WorkspaceSymbolIndex for the actual symbol lookup
+ * and converts results to the LSP SymbolInformation format.
+ */
+export class WorkspaceSymbolProvider {
+  constructor(private readonly index: WorkspaceSymbolIndex) {}
+
+  /**
+   * Provide workspace symbols matching the given query.
+   *
+   * @param query      - The search query from the user
+   * @param maxResults - Maximum number of results to return
+   * @returns Array of SymbolInformation for matching symbols
+   */
+  provideWorkspaceSymbols(
+    query: string,
+    maxResults: number = DEFAULT_MAX_RESULTS
+  ): SymbolInformation[] {
+    const matches = this.index.search(query, maxResults);
+    return matches.map((symbol) =>
+      SymbolInformation.create(symbol.name, symbol.kind, symbol.range, symbol.fileUri)
+    );
+  }
+}

--- a/src/providers/WorkspaceSymbolProvider.ts
+++ b/src/providers/WorkspaceSymbolProvider.ts
@@ -7,10 +7,7 @@
  */
 import { SymbolInformation } from 'vscode-languageserver/node';
 
-import { WorkspaceSymbolIndex } from './WorkspaceSymbolIndex';
-
-/** Default maximum number of results to return from a workspace symbol search. */
-const DEFAULT_MAX_RESULTS = 100;
+import { DEFAULT_MAX_RESULTS, WorkspaceSymbolIndex } from './WorkspaceSymbolIndex';
 
 /**
  * Provider for LSP `workspace/symbol` requests.

--- a/src/providers/WorkspaceSymbolProvider.ts
+++ b/src/providers/WorkspaceSymbolProvider.ts
@@ -7,7 +7,10 @@
  */
 import { SymbolInformation } from 'vscode-languageserver/node';
 
-import { DEFAULT_MAX_RESULTS, WorkspaceSymbolIndex } from './WorkspaceSymbolIndex';
+import { WorkspaceSymbolIndex } from './WorkspaceSymbolIndex';
+
+/** Default maximum number of symbols to return from a search query. */
+const DEFAULT_MAX_RESULTS = 100;
 
 /**
  * Provider for LSP `workspace/symbol` requests.

--- a/src/providers/WorkspaceSymbolVisitor.ts
+++ b/src/providers/WorkspaceSymbolVisitor.ts
@@ -1,0 +1,101 @@
+/**
+ * Workspace Symbol Visitor
+ *
+ * AST visitor that extracts workspace-level symbols from a G-code AST.
+ * Collects subroutine definitions, subroutine labels, line numbers,
+ * and variable definitions (first assignment only) for cross-file search.
+ */
+import { SymbolKind } from 'vscode-languageserver/node';
+
+import { BaseAstVisitor } from '../parser/BaseAstVisitor';
+import {
+  LineNumberNode,
+  SubroutineDefinitionNode,
+  SubroutineLabelNode,
+  VariableAssignmentNode,
+} from '../parser/nodes';
+import { Range } from '../parser/nodes/Range';
+import { formatVariableName } from './RenameUtils';
+
+/**
+ * Represents a symbol extracted from a workspace file.
+ * Contains enough information to build an LSP SymbolInformation.
+ */
+export interface WorkspaceSymbol {
+  /** Display name of the symbol (e.g. "O100", "N50", "#<feed>") */
+  readonly name: string;
+  /** LSP symbol kind */
+  readonly kind: SymbolKind;
+  /** Range of the symbol in the source file */
+  readonly range: Range;
+  /** URI of the file containing this symbol */
+  readonly fileUri: string;
+}
+
+/**
+ * AST visitor that collects workspace-level symbols.
+ *
+ * Extracts:
+ * - Subroutine definitions (O-blocks with SUB/ENDSUB, PROC)
+ * - Subroutine labels (standalone O-block labels)
+ * - Line numbers (N-blocks)
+ * - Variable definitions (first assignment of each variable)
+ */
+export class WorkspaceSymbolVisitor extends BaseAstVisitor<void> {
+  private readonly symbols: WorkspaceSymbol[] = [];
+  private readonly seenVariables = new Set<string | number>();
+
+  constructor(private readonly fileUri: string) {
+    super();
+  }
+
+  protected defaultValue(): void {
+    return;
+  }
+
+  getSymbols(): readonly WorkspaceSymbol[] {
+    return this.symbols;
+  }
+
+  visitSubroutineDefinition(node: SubroutineDefinitionNode): void {
+    this.symbols.push({
+      name: node.label,
+      kind: SymbolKind.Function,
+      range: node.labelTokenRange,
+      fileUri: this.fileUri,
+    });
+  }
+
+  visitSubroutineLabel(node: SubroutineLabelNode): void {
+    this.symbols.push({
+      name: node.label,
+      kind: SymbolKind.Key,
+      range: node.getRange(),
+      fileUri: this.fileUri,
+    });
+  }
+
+  visitLineNumber(node: LineNumberNode): void {
+    this.symbols.push({
+      name: node.lineNumber,
+      kind: SymbolKind.Constant,
+      range: node.getRange(),
+      fileUri: this.fileUri,
+    });
+  }
+
+  visitVariableAssignment(node: VariableAssignmentNode): void {
+    // Only record the first assignment of each variable
+    if (this.seenVariables.has(node.name)) {
+      return;
+    }
+    this.seenVariables.add(node.name);
+
+    this.symbols.push({
+      name: formatVariableName(node.name),
+      kind: SymbolKind.Variable,
+      range: node.variableTokenRange,
+      fileUri: this.fileUri,
+    });
+  }
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -116,7 +116,19 @@ connection.onDidChangeConfiguration(() => {
   documentStateManager.clearAll();
   workspaceSymbolIndex.clear();
   connection.console.log('Configuration changed - caches cleared');
+
+  // Re-apply workspace settings after cache invalidation
+  void applyWorkspaceSettings();
 });
+
+/**
+ * Reads workspace-level settings from the config provider
+ * and applies them to the workspace symbol index.
+ */
+async function applyWorkspaceSettings(): Promise<void> {
+  const config = await configProvider.getConfig();
+  workspaceSymbolIndex.setMaxSymbols(config.workspace.maxSymbols);
+}
 
 /**
  * Fetches the scoped {@link GCodeConfig} for a document URI and
@@ -357,14 +369,17 @@ documents.onDidChangeContent((change) => {
     uri,
     setTimeout(() => {
       diagnosticsTimers.delete(uri);
-      void getDocumentSettings(uri).then((settings) => {
+      void configProvider.getConfig(uri).then((config) => {
+        const settings = toGCodeSettings(config);
         const diagnostics = diagnosticsProvider.provideDiagnostics(change.document, settings);
         connection.sendDiagnostics({ uri, diagnostics }).catch((error: Error) => {
           connection.console.error(`Failed to send diagnostics for ${uri}: ${error.message}`);
         });
 
-        // Update workspace symbol index
-        workspaceSymbolIndex.indexFile(uri, change.document.getText(), settings.dialect);
+        // Update workspace symbol index if indexing is enabled
+        if (config.workspace.indexingEnabled) {
+          workspaceSymbolIndex.indexFile(uri, change.document.getText(), config.dialect);
+        }
       });
     }, DIAGNOSTICS_DEBOUNCE_MS)
   );
@@ -372,8 +387,9 @@ documents.onDidChangeContent((change) => {
 
 // Also publish diagnostics when document is opened
 documents.onDidOpen(async (event) => {
-  const settings = await getDocumentSettings(event.document.uri),
-    diagnostics = diagnosticsProvider.provideDiagnostics(event.document, settings);
+  const config = await configProvider.getConfig(event.document.uri);
+  const settings = toGCodeSettings(config);
+  const diagnostics = diagnosticsProvider.provideDiagnostics(event.document, settings);
   connection
     .sendDiagnostics({
       uri: event.document.uri,
@@ -385,8 +401,10 @@ documents.onDidOpen(async (event) => {
       );
     });
 
-  // Index file for workspace symbol search
-  workspaceSymbolIndex.indexFile(event.document.uri, event.document.getText(), settings.dialect);
+  // Index file for workspace symbol search if indexing is enabled
+  if (config.workspace.indexingEnabled) {
+    workspaceSymbolIndex.indexFile(event.document.uri, event.document.getText(), config.dialect);
+  }
 });
 
 // Clean up caches and timers when a document is closed

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -163,9 +163,9 @@ const formatterService = new FormatterService(),
   hoverProvider = new HoverProvider(documentStateManager),
   diagnosticsProvider = new DiagnosticsProvider(documentStateManager),
   codeActionProvider = new CodeActionProvider(),
-  completionProvider = new CompletionProvider(documentStateManager),
-  workspaceSymbolIndex = new WorkspaceSymbolIndex(),
-  workspaceSymbolProvider = new WorkspaceSymbolProvider(workspaceSymbolIndex);
+  completionProvider = new CompletionProvider(documentStateManager);
+const workspaceSymbolIndex = new WorkspaceSymbolIndex();
+const workspaceSymbolProvider = new WorkspaceSymbolProvider(workspaceSymbolIndex);
 
 connection.onDocumentFormatting(async (params) => {
   const document = documents.get(params.textDocument.uri);
@@ -441,6 +441,7 @@ connection.languages.diagnostics.on(async (params) => {
 
 connection.onInitialized(() => {
   connection.console.log('G-code Language Server initialized');
+  void applyWorkspaceSettings();
 });
 
 // Make the text document manager listen on the connection

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -29,6 +29,8 @@ import { CompletionProvider } from '../providers/CompletionProvider';
 import { FoldingRangeProvider } from '../providers/FoldingRangeProvider';
 import { GCodeConfig } from '../config/types';
 import { ServerConfigProvider } from '../config/server-config-provider/ServerConfigProvider';
+import { WorkspaceSymbolIndex } from '../providers/WorkspaceSymbolIndex';
+import { WorkspaceSymbolProvider } from '../providers/WorkspaceSymbolProvider';
 
 // Create a connection to the client
 const connection = createConnection(ProposedFeatures.all);
@@ -68,6 +70,8 @@ connection.onInitialize((_params: InitializeParams): InitializeResult => {
         interFileDependencies: false,
         workspaceDiagnostics: false,
       },
+      // Enable workspace symbol search (Ctrl+T)
+      workspaceSymbolProvider: true,
       // Enable completion with trigger characters
       completionProvider: {
         triggerCharacters: [
@@ -110,6 +114,7 @@ connection.onDidChangeConfiguration(() => {
   // Clear cached config and document states when configuration changes
   configProvider.invalidate();
   documentStateManager.clearAll();
+  workspaceSymbolIndex.clear();
   connection.console.log('Configuration changed - caches cleared');
 });
 
@@ -146,7 +151,9 @@ const formatterService = new FormatterService(),
   hoverProvider = new HoverProvider(documentStateManager),
   diagnosticsProvider = new DiagnosticsProvider(documentStateManager),
   codeActionProvider = new CodeActionProvider(),
-  completionProvider = new CompletionProvider(documentStateManager);
+  completionProvider = new CompletionProvider(documentStateManager),
+  workspaceSymbolIndex = new WorkspaceSymbolIndex(),
+  workspaceSymbolProvider = new WorkspaceSymbolProvider(workspaceSymbolIndex);
 
 connection.onDocumentFormatting(async (params) => {
   const document = documents.get(params.textDocument.uri);
@@ -276,6 +283,11 @@ connection.onCompletionResolve((item) => {
   return completionProvider.resolveCompletionItem(item);
 });
 
+// Register workspace symbol provider
+connection.onWorkspaceSymbol((params) => {
+  return workspaceSymbolProvider.provideWorkspaceSymbols(params.query);
+});
+
 // Register code action provider
 connection.onCodeAction(async (params) => {
   const document = documents.get(params.textDocument.uri);
@@ -350,6 +362,9 @@ documents.onDidChangeContent((change) => {
         connection.sendDiagnostics({ uri, diagnostics }).catch((error: Error) => {
           connection.console.error(`Failed to send diagnostics for ${uri}: ${error.message}`);
         });
+
+        // Update workspace symbol index
+        workspaceSymbolIndex.indexFile(uri, change.document.getText(), settings.dialect);
       });
     }, DIAGNOSTICS_DEBOUNCE_MS)
   );
@@ -369,6 +384,9 @@ documents.onDidOpen(async (event) => {
         `Failed to send diagnostics for ${event.document.uri}: ${error.message}`
       );
     });
+
+  // Index file for workspace symbol search
+  workspaceSymbolIndex.indexFile(event.document.uri, event.document.getText(), settings.dialect);
 });
 
 // Clean up caches and timers when a document is closed
@@ -380,6 +398,8 @@ documents.onDidClose((event) => {
     diagnosticsTimers.delete(uri);
   }
   documentStateManager.removeDocument(uri);
+  // Note: We intentionally keep workspace symbols indexed after close,
+  // so workspace symbol search still finds symbols from previously opened files.
 });
 
 // Register pull-based diagnostics handler (for newer VS Code versions)

--- a/src/test/providers/WorkspaceSymbolIndex.test.ts
+++ b/src/test/providers/WorkspaceSymbolIndex.test.ts
@@ -1,0 +1,238 @@
+import { SymbolKind } from 'vscode-languageserver/node';
+
+import { DialectType } from '../../constants';
+import { WorkspaceSymbolIndex } from '../../providers/WorkspaceSymbolIndex';
+
+describe('WorkspaceSymbolIndex', () => {
+  let index: WorkspaceSymbolIndex;
+
+  beforeEach(() => {
+    index = new WorkspaceSymbolIndex();
+  });
+
+  describe('indexFile', () => {
+    it('indexes symbols from a file', () => {
+      index.indexFile('file:///test.nc', 'O100 SUB\nG0 X10\nO100 ENDSUB');
+
+      expect(index.getSymbolCount()).toBe(1);
+      expect(index.getFileCount()).toBe(1);
+    });
+
+    it('indexes multiple files', () => {
+      index.indexFile('file:///file1.nc', 'O100 SUB\nO100 ENDSUB');
+      index.indexFile('file:///file2.nc', 'O200 SUB\nO200 ENDSUB');
+
+      expect(index.getFileCount()).toBe(2);
+      expect(index.getSymbolCount()).toBe(2);
+    });
+
+    it('replaces existing symbols when re-indexing a file', () => {
+      index.indexFile('file:///test.nc', 'O100 SUB\nO100 ENDSUB');
+      expect(index.getSymbolCount()).toBe(1);
+
+      index.indexFile('file:///test.nc', 'O200 SUB\nO200 ENDSUB\nO300 SUB\nO300 ENDSUB');
+      expect(index.getSymbolCount()).toBe(2);
+      expect(index.getFileCount()).toBe(1);
+    });
+
+    it('indexes variables, line numbers, and subroutines', () => {
+      const code = `N10 G0 X0
+O100 SUB
+#<feed> = 100
+O100 ENDSUB`;
+      index.indexFile('file:///test.nc', code);
+
+      const symbols = index.getFileSymbols('file:///test.nc');
+      expect(symbols).toHaveLength(3);
+    });
+
+    it('respects maxSymbols limit', () => {
+      const smallIndex = new WorkspaceSymbolIndex(2);
+
+      // This file has 3 symbols (N10, O100, #<feed>)
+      const code = `N10 G0 X0
+O100 SUB
+#<feed> = 100
+O100 ENDSUB`;
+      smallIndex.indexFile('file:///test.nc', code);
+
+      expect(smallIndex.getSymbolCount()).toBe(2);
+    });
+
+    it('does not index new files when maxSymbols reached', () => {
+      const smallIndex = new WorkspaceSymbolIndex(1);
+
+      smallIndex.indexFile('file:///file1.nc', 'O100 SUB\nO100 ENDSUB');
+      expect(smallIndex.getSymbolCount()).toBe(1);
+
+      smallIndex.indexFile('file:///file2.nc', 'O200 SUB\nO200 ENDSUB');
+      // file2 should still be indexed but with 0 symbols since limit is reached
+      expect(smallIndex.getSymbolCount()).toBe(1);
+    });
+
+    it('supports dialect-specific parsing', () => {
+      index.indexFile('file:///test.nc', 'O0001', DialectType.FANUC);
+
+      const symbols = index.getFileSymbols('file:///test.nc');
+      expect(symbols).toHaveLength(1);
+      expect(symbols[0].name).toBe('O0001');
+      expect(symbols[0].kind).toBe(SymbolKind.Key);
+    });
+  });
+
+  describe('removeFile', () => {
+    it('removes symbols for a file', () => {
+      index.indexFile('file:///test.nc', 'O100 SUB\nO100 ENDSUB');
+      expect(index.getSymbolCount()).toBe(1);
+
+      index.removeFile('file:///test.nc');
+      expect(index.getSymbolCount()).toBe(0);
+      expect(index.getFileCount()).toBe(0);
+    });
+
+    it('does not throw when removing non-existent file', () => {
+      expect(() => index.removeFile('file:///nonexistent.nc')).not.toThrow();
+    });
+
+    it('only removes symbols for the specified file', () => {
+      index.indexFile('file:///file1.nc', 'O100 SUB\nO100 ENDSUB');
+      index.indexFile('file:///file2.nc', 'O200 SUB\nO200 ENDSUB');
+
+      index.removeFile('file:///file1.nc');
+      expect(index.getSymbolCount()).toBe(1);
+      expect(index.getFileCount()).toBe(1);
+      expect(index.hasFile('file:///file2.nc')).toBe(true);
+    });
+  });
+
+  describe('hasFile', () => {
+    it('returns true for indexed files', () => {
+      index.indexFile('file:///test.nc', 'O100 SUB\nO100 ENDSUB');
+      expect(index.hasFile('file:///test.nc')).toBe(true);
+    });
+
+    it('returns false for non-indexed files', () => {
+      expect(index.hasFile('file:///nonexistent.nc')).toBe(false);
+    });
+  });
+
+  describe('search', () => {
+    beforeEach(() => {
+      index.indexFile(
+        'file:///main.nc',
+        `N10 G0 X0
+O100 SUB
+#<feed> = 100
+O100 ENDSUB`
+      );
+      index.indexFile(
+        'file:///library.nc',
+        `O200 SUB
+#<speed> = 500
+O200 ENDSUB`
+      );
+    });
+
+    it('returns all symbols for empty query', () => {
+      const results = index.search('');
+
+      // N10, O100, #<feed>, O200, #<speed> = 5 symbols
+      expect(results.length).toBe(5);
+    });
+
+    it('finds symbols by exact name', () => {
+      const results = index.search('O100');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('O100');
+    });
+
+    it('finds symbols by partial name (substring match)', () => {
+      const results = index.search('O');
+
+      // O100 and O200
+      expect(results.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('performs case-insensitive search', () => {
+      const results = index.search('o100');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('O100');
+    });
+
+    it('finds variables by name', () => {
+      const results = index.search('feed');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('#<feed>');
+    });
+
+    it('finds line numbers', () => {
+      const results = index.search('N10');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('N10');
+    });
+
+    it('returns empty array when no matches', () => {
+      const results = index.search('NONEXISTENT');
+
+      expect(results).toEqual([]);
+    });
+
+    it('respects maxResults parameter', () => {
+      const results = index.search('', 2);
+
+      expect(results).toHaveLength(2);
+    });
+
+    it('sorts prefix matches before substring matches', () => {
+      index.indexFile('file:///extra.nc', '#<offset_x> = 0');
+
+      const results = index.search('O');
+
+      // O100 and O200 are prefix matches, #<offset_x> is a substring match
+      const prefixMatches = results.filter((symbol) => symbol.name.toLowerCase().startsWith('o'));
+      const substringMatches = results.filter(
+        (symbol) =>
+          !symbol.name.toLowerCase().startsWith('o') && symbol.name.toLowerCase().includes('o')
+      );
+
+      // Prefix matches should come before substring matches
+      if (prefixMatches.length > 0 && substringMatches.length > 0) {
+        const lastPrefixIndex = results.indexOf(prefixMatches[prefixMatches.length - 1]);
+        const firstSubstringIndex = results.indexOf(substringMatches[0]);
+        expect(lastPrefixIndex).toBeLessThan(firstSubstringIndex);
+      }
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all indexed symbols', () => {
+      index.indexFile('file:///file1.nc', 'O100 SUB\nO100 ENDSUB');
+      index.indexFile('file:///file2.nc', 'O200 SUB\nO200 ENDSUB');
+
+      index.clear();
+
+      expect(index.getSymbolCount()).toBe(0);
+      expect(index.getFileCount()).toBe(0);
+    });
+  });
+
+  describe('setMaxSymbols', () => {
+    it('updates the maximum symbols limit', () => {
+      index.setMaxSymbols(1);
+
+      // This has multiple symbols but should only keep 1
+      index.indexFile(
+        'file:///test.nc',
+        `N10 G0 X0
+O100 SUB
+O100 ENDSUB`
+      );
+
+      expect(index.getSymbolCount()).toBe(1);
+    });
+  });
+});

--- a/src/test/providers/WorkspaceSymbolProvider.test.ts
+++ b/src/test/providers/WorkspaceSymbolProvider.test.ts
@@ -1,0 +1,95 @@
+import { SymbolKind } from 'vscode-languageserver/node';
+
+import { WorkspaceSymbolIndex } from '../../providers/WorkspaceSymbolIndex';
+import { WorkspaceSymbolProvider } from '../../providers/WorkspaceSymbolProvider';
+
+describe('WorkspaceSymbolProvider', () => {
+  let index: WorkspaceSymbolIndex;
+  let provider: WorkspaceSymbolProvider;
+
+  beforeEach(() => {
+    index = new WorkspaceSymbolIndex();
+    provider = new WorkspaceSymbolProvider(index);
+
+    // Set up index with test data
+    index.indexFile(
+      'file:///main.nc',
+      `N10 G0 X0
+O100 SUB
+#<feed> = 100
+O100 ENDSUB`
+    );
+    index.indexFile(
+      'file:///library.nc',
+      `O200 SUB
+#<speed> = 500
+O200 ENDSUB`
+    );
+  });
+
+  describe('provideWorkspaceSymbols', () => {
+    it('returns SymbolInformation array for matching query', () => {
+      const results = provider.provideWorkspaceSymbols('O100');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('O100');
+      expect(results[0].kind).toBe(SymbolKind.Function);
+      expect(results[0].location.uri).toBe('file:///main.nc');
+    });
+
+    it('returns all symbols for empty query', () => {
+      const results = provider.provideWorkspaceSymbols('');
+
+      expect(results.length).toBe(5);
+    });
+
+    it('returns empty array when no matches', () => {
+      const results = provider.provideWorkspaceSymbols('NONEXISTENT');
+
+      expect(results).toEqual([]);
+    });
+
+    it('includes correct location info', () => {
+      const results = provider.provideWorkspaceSymbols('O200');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].location.uri).toBe('file:///library.nc');
+      expect(results[0].location.range).toBeDefined();
+      expect(results[0].location.range.start).toBeDefined();
+      expect(results[0].location.range.end).toBeDefined();
+    });
+
+    it('respects maxResults parameter', () => {
+      const results = provider.provideWorkspaceSymbols('', 2);
+
+      expect(results).toHaveLength(2);
+    });
+
+    it('finds symbols across multiple files', () => {
+      const results = provider.provideWorkspaceSymbols('O');
+
+      expect(results.length).toBeGreaterThanOrEqual(2);
+
+      const uris = new Set(results.map((symbol) => symbol.location.uri));
+      expect(uris.size).toBeGreaterThanOrEqual(2);
+    });
+
+    it('returns correct symbol kinds', () => {
+      const subroutineResults = provider.provideWorkspaceSymbols('O100');
+      expect(subroutineResults[0].kind).toBe(SymbolKind.Function);
+
+      const variableResults = provider.provideWorkspaceSymbols('feed');
+      expect(variableResults[0].kind).toBe(SymbolKind.Variable);
+
+      const lineNumberResults = provider.provideWorkspaceSymbols('N10');
+      expect(lineNumberResults[0].kind).toBe(SymbolKind.Constant);
+    });
+
+    it('performs case-insensitive search', () => {
+      const results = provider.provideWorkspaceSymbols('o100');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('O100');
+    });
+  });
+});

--- a/src/test/providers/WorkspaceSymbolVisitor.test.ts
+++ b/src/test/providers/WorkspaceSymbolVisitor.test.ts
@@ -72,8 +72,16 @@ describe('WorkspaceSymbolVisitor', () => {
   });
 
   describe('subroutine labels', () => {
-    it('extracts standalone O-block label as Key symbol', () => {
+    it('extracts standalone O-block label as Key symbol (Fanuc)', () => {
       const symbols = getWorkspaceSymbols('O0001', TEST_URI, DialectType.FANUC);
+
+      expect(symbols).toHaveLength(1);
+      expect(symbols[0].name).toBe('O0001');
+      expect(symbols[0].kind).toBe(SymbolKind.Key);
+    });
+
+    it('extracts standalone O-block label as Key symbol (Haas)', () => {
+      const symbols = getWorkspaceSymbols('O0001', TEST_URI, DialectType.HAAS);
 
       expect(symbols).toHaveLength(1);
       expect(symbols[0].name).toBe('O0001');

--- a/src/test/providers/WorkspaceSymbolVisitor.test.ts
+++ b/src/test/providers/WorkspaceSymbolVisitor.test.ts
@@ -1,0 +1,176 @@
+import { SymbolKind } from 'vscode-languageserver/node';
+
+import { DialectType } from '../../constants';
+import { LexerFactory } from '../../lexer/LexerFactory';
+import { AstTraverser } from '../../parser/AstTraverser';
+import { ProgramNode } from '../../parser/nodes';
+import { ParserFactory } from '../../parser/ParserFactory';
+import { WorkspaceSymbol, WorkspaceSymbolVisitor } from '../../providers/WorkspaceSymbolVisitor';
+
+const TEST_URI = 'file:///test.nc';
+
+function parse(code: string, dialect: DialectType = DialectType.LINUXCNC): ProgramNode {
+  const lexer = LexerFactory.create(dialect);
+  const tokens = lexer.tokenize(code);
+  const parser = ParserFactory.create(dialect, tokens, code);
+  return parser.parseProgram();
+}
+
+function getWorkspaceSymbols(
+  code: string,
+  uri: string = TEST_URI,
+  dialect: DialectType = DialectType.LINUXCNC
+): readonly WorkspaceSymbol[] {
+  const ast = parse(code, dialect);
+  const visitor = new WorkspaceSymbolVisitor(uri);
+  const traverser = new AstTraverser(visitor);
+  traverser.traverseProgram(ast);
+  return visitor.getSymbols();
+}
+
+describe('WorkspaceSymbolVisitor', () => {
+  describe('empty and simple programs', () => {
+    it('returns empty array for empty program', () => {
+      expect(getWorkspaceSymbols('')).toEqual([]);
+    });
+
+    it('returns empty array for motion-only program', () => {
+      expect(getWorkspaceSymbols('G0 X10 Y20\nG1 X30 F100')).toEqual([]);
+    });
+  });
+
+  describe('subroutine definitions', () => {
+    it('extracts subroutine definition as Function symbol', () => {
+      const symbols = getWorkspaceSymbols('O100 SUB\nG0 X10\nO100 ENDSUB');
+
+      expect(symbols).toHaveLength(1);
+      expect(symbols[0].name).toBe('O100');
+      expect(symbols[0].kind).toBe(SymbolKind.Function);
+      expect(symbols[0].fileUri).toBe(TEST_URI);
+    });
+
+    it('extracts multiple subroutine definitions', () => {
+      const code = 'O100 SUB\nO100 ENDSUB\nO200 SUB\nO200 ENDSUB';
+      const symbols = getWorkspaceSymbols(code);
+
+      expect(symbols).toHaveLength(2);
+      expect(symbols[0].name).toBe('O100');
+      expect(symbols[1].name).toBe('O200');
+    });
+
+    it('extracts Siemens PROC definitions', () => {
+      const symbols = getWorkspaceSymbols(
+        'PROC MyProc\nG0 X10\nRET',
+        TEST_URI,
+        DialectType.SIEMENS
+      );
+
+      expect(symbols).toHaveLength(1);
+      expect(symbols[0].name).toBe('MyProc');
+      expect(symbols[0].kind).toBe(SymbolKind.Function);
+    });
+  });
+
+  describe('subroutine labels', () => {
+    it('extracts standalone O-block label as Key symbol', () => {
+      const symbols = getWorkspaceSymbols('O0001', DialectType.FANUC);
+
+      expect(symbols).toHaveLength(1);
+      expect(symbols[0].name).toBe('O0001');
+      expect(symbols[0].kind).toBe(SymbolKind.Key);
+    });
+  });
+
+  describe('line numbers', () => {
+    it('extracts line numbers as Constant symbols', () => {
+      const symbols = getWorkspaceSymbols('N10 G0 X0\nN20 G1 X10');
+
+      expect(symbols).toHaveLength(2);
+      expect(symbols[0].name).toBe('N10');
+      expect(symbols[0].kind).toBe(SymbolKind.Constant);
+      expect(symbols[1].name).toBe('N20');
+    });
+  });
+
+  describe('variable definitions', () => {
+    it('extracts named variable as Variable symbol', () => {
+      const symbols = getWorkspaceSymbols('#<feed> = 100');
+
+      expect(symbols).toHaveLength(1);
+      expect(symbols[0].name).toBe('#<feed>');
+      expect(symbols[0].kind).toBe(SymbolKind.Variable);
+    });
+
+    it('extracts numeric variable as Variable symbol', () => {
+      const symbols = getWorkspaceSymbols('#1 = 100');
+
+      expect(symbols).toHaveLength(1);
+      expect(symbols[0].name).toBe('#1');
+      expect(symbols[0].kind).toBe(SymbolKind.Variable);
+    });
+
+    it('records only the first assignment of each variable', () => {
+      const code = '#<x> = 10\n#<x> = 20\n#<x> = 30';
+      const symbols = getWorkspaceSymbols(code);
+
+      expect(symbols).toHaveLength(1);
+      expect(symbols[0].name).toBe('#<x>');
+      expect(symbols[0].range.start.line).toBe(0);
+    });
+
+    it('records each unique variable once', () => {
+      const code = '#<x> = 10\n#<y> = 20\n#<x> = 30';
+      const symbols = getWorkspaceSymbols(code);
+
+      expect(symbols).toHaveLength(2);
+      expect(symbols[0].name).toBe('#<x>');
+      expect(symbols[1].name).toBe('#<y>');
+    });
+  });
+
+  describe('mixed symbol types', () => {
+    it('extracts all symbol types from a program', () => {
+      const code = `N10 G0 X0
+O100 SUB
+#<feed> = 100
+G1 X10 F#<feed>
+O100 ENDSUB`;
+      const symbols = getWorkspaceSymbols(code);
+
+      expect(symbols).toHaveLength(3);
+      expect(symbols[0].name).toBe('N10');
+      expect(symbols[0].kind).toBe(SymbolKind.Constant);
+      expect(symbols[1].name).toBe('O100');
+      expect(symbols[1].kind).toBe(SymbolKind.Function);
+      expect(symbols[2].name).toBe('#<feed>');
+      expect(symbols[2].kind).toBe(SymbolKind.Variable);
+    });
+  });
+
+  describe('file URI tracking', () => {
+    it('sets correct file URI on all symbols', () => {
+      const customUri = 'file:///workspace/subroutines.nc';
+      const symbols = getWorkspaceSymbols('#<x> = 10\nO100 SUB\nO100 ENDSUB', customUri);
+
+      for (const symbol of symbols) {
+        expect(symbol.fileUri).toBe(customUri);
+      }
+    });
+  });
+
+  describe('symbol ranges', () => {
+    it('provides correct range for subroutine definition label', () => {
+      const symbols = getWorkspaceSymbols('O100 SUB\nG0 X10\nO100 ENDSUB');
+
+      // Range should point to the label token, not the entire definition
+      expect(symbols[0].range.start.line).toBe(0);
+    });
+
+    it('provides correct range for line number', () => {
+      const symbols = getWorkspaceSymbols('N50 G0 X0');
+
+      expect(symbols[0].range.start.line).toBe(0);
+      expect(symbols[0].range.start.character).toBe(0);
+    });
+  });
+});

--- a/src/test/providers/WorkspaceSymbolVisitor.test.ts
+++ b/src/test/providers/WorkspaceSymbolVisitor.test.ts
@@ -73,7 +73,7 @@ describe('WorkspaceSymbolVisitor', () => {
 
   describe('subroutine labels', () => {
     it('extracts standalone O-block label as Key symbol', () => {
-      const symbols = getWorkspaceSymbols('O0001', DialectType.FANUC);
+      const symbols = getWorkspaceSymbols('O0001', TEST_URI, DialectType.FANUC);
 
       expect(symbols).toHaveLength(1);
       expect(symbols[0].name).toBe('O0001');


### PR DESCRIPTION
## Summary

Implements #23 — Workspace Symbols (Multi-file Navigation).

- **WorkspaceSymbolVisitor** — AST visitor extracting O-block subroutines, line numbers, and first variable assignments
- **WorkspaceSymbolIndex** — in-memory index with fuzzy/substring search, prefix-match ranking, and configurable capacity limits
- **WorkspaceSymbolProvider** — LSP handler returning `SymbolInformation[]`
- Settings: `gcode.workspace.indexingEnabled` (boolean) and `gcode.workspace.maxSymbols` (integer) wired through to the index
- 47 unit tests + 4 E2E tests

### Known limitation

Currently only indexes open documents, not all workspace files. A future enhancement could add a file watcher to scan all `.nc`/`.gcode` files at startup.

Closes #23

## Manual testing

1. Open a workspace with multiple `.nc` files
2. Open several files containing O-block subroutines, N-lines, and variable assignments
3. Press `Ctrl+T` and search for a subroutine name (e.g., `O0001`)
4. Verify results appear with correct file location
5. Click a result — verify it navigates to the correct line
6. Try partial/fuzzy search (e.g., `O0` should match multiple subroutines)
7. Set `gcode.workspace.indexingEnabled` to `false` in settings — verify search returns no results
8. Set `gcode.workspace.maxSymbols` to a small number (e.g., 5) — verify index respects the limit