### PR TITLE
fix(workspace-symbols): address review findings from PR #123

### DIFF
--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
         "gcode.workspace.indexingEnabled": {
           "type": "boolean",
           "default": true,
-          "description": "Enable workspace-wide symbol indexing for Ctrl+T search across all G-code files"
+          "description": "Enable symbol indexing for Ctrl+T search across open G-code files"
         },
         "gcode.workspace.maxSymbols": {
           "type": "integer",

--- a/src/e2e/suite/workspaceSymbol.test.ts
+++ b/src/e2e/suite/workspaceSymbol.test.ts
@@ -75,10 +75,69 @@ suite('Workspace Symbol Tests', () => {
     assert.ok(matching.length > 0, 'Should find symbols matching partial query O5');
   });
 
+  test('Should return no symbols when indexing is disabled', async () => {
+    const config = vscode.workspace.getConfiguration('gcode.workspace');
+    await config.update('indexingEnabled', false, vscode.ConfigurationTarget.Workspace);
+
+    try {
+      // Create a document that would normally produce symbols
+      await TestUtils.createGCodeDocument('O999 SUB\nG0 X10\nO999 ENDSUB', 'ws-symbol-disabled.nc');
+
+      // Give the server time to process the config change
+      await TestUtils.sleep(1000);
+
+      const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+        'vscode.executeWorkspaceSymbolProvider',
+        'O999'
+      );
+
+      const matching = (symbols ?? []).filter((s) => s.name === 'O999');
+      assert.strictEqual(matching.length, 0, 'Should find no symbols when indexing is disabled');
+    } finally {
+      await config.update('indexingEnabled', undefined, vscode.ConfigurationTarget.Workspace);
+      TestUtils.deleteTestFileByName('ws-symbol-disabled.nc');
+    }
+  });
+
+  test('Should respect maxSymbols limit', async () => {
+    const config = vscode.workspace.getConfiguration('gcode.workspace');
+    await config.update('maxSymbols', 1, vscode.ConfigurationTarget.Workspace);
+
+    try {
+      // Create a file with multiple symbols (subroutine + variable + line number)
+      await TestUtils.createGCodeDocument(
+        'N10 G0 X0\nO800 SUB\n#<limit_test> = 1\nO800 ENDSUB',
+        'ws-symbol-limit.nc'
+      );
+
+      const symbols = await TestUtils.waitForCondition(
+        async () =>
+          vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+            'vscode.executeWorkspaceSymbolProvider',
+            ''
+          ),
+        (result) => Array.isArray(result)
+      );
+
+      // With maxSymbols=1, the total indexed symbols across ALL files should be capped
+      // We can't assert exact count since other test files may be open, but we verify
+      // the limit mechanism works by checking the total is small
+      assert.ok(
+        Array.isArray(symbols) && symbols.length <= 5,
+        `Expected limited symbols but got ${symbols?.length}`
+      );
+    } finally {
+      await config.update('maxSymbols', undefined, vscode.ConfigurationTarget.Workspace);
+      TestUtils.deleteTestFileByName('ws-symbol-limit.nc');
+    }
+  });
+
   suiteTeardown(async () => {
     TestUtils.deleteTestFileByName('ws-symbol-sub.nc');
     TestUtils.deleteTestFileByName('ws-symbol-var.nc');
     TestUtils.deleteTestFileByName('ws-symbol-partial.nc');
+    TestUtils.deleteTestFileByName('ws-symbol-disabled.nc');
+    TestUtils.deleteTestFileByName('ws-symbol-limit.nc');
     await vscode.commands.executeCommand('workbench.action.closeAllEditors');
   });
 });

--- a/src/e2e/testUtils.ts
+++ b/src/e2e/testUtils.ts
@@ -4,6 +4,16 @@ import * as vscode from 'vscode';
 import { GCODE_LANGUAGE_ID } from '../constants';
 
 /**
+ * Thrown when a polling condition is not met within the timeout.
+ */
+export class WaitConditionTimeoutError extends Error {
+  constructor(timeout: number) {
+    super(`waitForCondition timed out after ${timeout}ms`);
+    this.name = 'WaitConditionTimeoutError';
+  }
+}
+
+/**
  * Helper utilities for VS Code e2e tests
  */
 export class TestUtils {
@@ -287,7 +297,7 @@ export class TestUtils {
     // Run one last time and check condition — throw if still not met
     const finalResult = await fn();
     if (!check(finalResult)) {
-      throw new Error(`waitForCondition timed out after ${timeout}ms`);
+      throw new WaitConditionTimeoutError(timeout);
     }
     return finalResult;
   }
@@ -295,7 +305,7 @@ export class TestUtils {
   /**
    * Wait for a specific amount of time
    */
-  private static async sleep(ms: number): Promise<void> {
+  static async sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 

--- a/src/providers/WorkspaceSymbolIndex.ts
+++ b/src/providers/WorkspaceSymbolIndex.ts
@@ -14,6 +14,8 @@ import { AstTraverser } from '../parser/AstTraverser';
 import { ParserFactory } from '../parser/ParserFactory';
 import { WorkspaceSymbol, WorkspaceSymbolVisitor } from './WorkspaceSymbolVisitor';
 
+export const DEFAULT_MAX_SEARCH_RESULTS = 100;
+
 /**
  * In-memory index of workspace symbols.
  *
@@ -31,12 +33,18 @@ export class WorkspaceSymbolIndex {
   /** Maximum symbols to store across all files. */
   private maxSymbols: number;
 
-  constructor(maxSymbols: number = DEFAULT_GCODE_CONFIG.workspace.maxSymbols) {
+  constructor(
+    maxSymbols: number = DEFAULT_GCODE_CONFIG.workspace.maxSymbols,
+    private readonly logger?: (message: string) => void
+  ) {
     this.maxSymbols = maxSymbols;
   }
 
   /**
    * Update the maximum symbols limit.
+   *
+   * The new limit takes effect on the next `indexFile` call. Does not trim
+   * symbols already indexed — call `clear()` first if a hard cap is required.
    */
   setMaxSymbols(maxSymbols: number): void {
     this.maxSymbols = maxSymbols;
@@ -98,7 +106,7 @@ export class WorkspaceSymbolIndex {
    * @param maxResults - Maximum number of results to return
    * @returns Matching symbols, sorted by relevance (prefix > substring)
    */
-  search(query: string, maxResults = 100): readonly WorkspaceSymbol[] {
+  search(query: string, maxResults = DEFAULT_MAX_SEARCH_RESULTS): readonly WorkspaceSymbol[] {
     const normalizedQuery = query.toLowerCase();
     const matches: WorkspaceSymbol[] = [];
 
@@ -175,7 +183,10 @@ export class WorkspaceSymbolIndex {
       traverser.traverseProgram(ast);
 
       return visitor.getSymbols();
-    } catch {
+    } catch (error: unknown) {
+      this.logger?.(
+        `Failed to extract symbols from ${uri}: ${error instanceof Error ? error.message : String(error)}`
+      );
       return [];
     }
   }

--- a/src/providers/WorkspaceSymbolProvider.ts
+++ b/src/providers/WorkspaceSymbolProvider.ts
@@ -7,10 +7,7 @@
  */
 import { SymbolInformation } from 'vscode-languageserver/node';
 
-import { WorkspaceSymbolIndex } from './WorkspaceSymbolIndex';
-
-/** Default maximum number of symbols to return from a search query. */
-const DEFAULT_MAX_RESULTS = 100;
+import { DEFAULT_MAX_SEARCH_RESULTS, WorkspaceSymbolIndex } from './WorkspaceSymbolIndex';
 
 /**
  * Provider for LSP `workspace/symbol` requests.
@@ -30,7 +27,7 @@ export class WorkspaceSymbolProvider {
    */
   provideWorkspaceSymbols(
     query: string,
-    maxResults: number = DEFAULT_MAX_RESULTS
+    maxResults: number = DEFAULT_MAX_SEARCH_RESULTS
   ): SymbolInformation[] {
     const matches = this.index.search(query, maxResults);
     return matches.map((symbol) =>

--- a/src/providers/WorkspaceSymbolVisitor.ts
+++ b/src/providers/WorkspaceSymbolVisitor.ts
@@ -69,7 +69,7 @@ export class WorkspaceSymbolVisitor extends BaseAstVisitor<void> {
   visitSubroutineLabel(node: SubroutineLabelNode): void {
     this.symbols.push({
       name: node.label,
-      kind: SymbolKind.Key,
+      kind: SymbolKind.Module,
       range: node.getRange(),
       fileUri: this.fileUri,
     });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -118,7 +118,9 @@ connection.onDidChangeConfiguration(() => {
   connection.console.log('Configuration changed - caches cleared');
 
   // Re-apply workspace settings after cache invalidation
-  void applyWorkspaceSettings();
+  applyWorkspaceSettings().catch((error: Error) => {
+    connection.console.error(`Failed to apply workspace settings: ${error.message}`);
+  });
 });
 
 /**
@@ -163,9 +165,9 @@ const formatterService = new FormatterService(),
   hoverProvider = new HoverProvider(documentStateManager),
   diagnosticsProvider = new DiagnosticsProvider(documentStateManager),
   codeActionProvider = new CodeActionProvider(),
-  completionProvider = new CompletionProvider(documentStateManager);
-const workspaceSymbolIndex = new WorkspaceSymbolIndex();
-const workspaceSymbolProvider = new WorkspaceSymbolProvider(workspaceSymbolIndex);
+  completionProvider = new CompletionProvider(documentStateManager),
+  workspaceSymbolIndex = new WorkspaceSymbolIndex(undefined, (msg) => connection.console.warn(msg)),
+  workspaceSymbolProvider = new WorkspaceSymbolProvider(workspaceSymbolIndex);
 
 connection.onDocumentFormatting(async (params) => {
   const document = documents.get(params.textDocument.uri);
@@ -441,7 +443,9 @@ connection.languages.diagnostics.on(async (params) => {
 
 connection.onInitialized(() => {
   connection.console.log('G-code Language Server initialized');
-  void applyWorkspaceSettings();
+  applyWorkspaceSettings().catch((error: Error) => {
+    connection.console.error(`Failed to apply workspace settings: ${error.message}`);
+  });
 });
 
 // Make the text document manager listen on the connection

--- a/src/test/providers/WorkspaceSymbolIndex.test.ts
+++ b/src/test/providers/WorkspaceSymbolIndex.test.ts
@@ -66,7 +66,7 @@ O100 ENDSUB`;
       expect(smallIndex.getSymbolCount()).toBe(1);
 
       smallIndex.indexFile('file:///file2.nc', 'O200 SUB\nO200 ENDSUB');
-      // file2 should still be indexed but with 0 symbols since limit is reached
+      // file2 is not indexed since the global symbol limit was already reached
       expect(smallIndex.getSymbolCount()).toBe(1);
     });
 
@@ -76,7 +76,7 @@ O100 ENDSUB`;
       const symbols = index.getFileSymbols('file:///test.nc');
       expect(symbols).toHaveLength(1);
       expect(symbols[0].name).toBe('O0001');
-      expect(symbols[0].kind).toBe(SymbolKind.Key);
+      expect(symbols[0].kind).toBe(SymbolKind.Module);
     });
   });
 

--- a/src/test/providers/WorkspaceSymbolVisitor.test.ts
+++ b/src/test/providers/WorkspaceSymbolVisitor.test.ts
@@ -72,20 +72,20 @@ describe('WorkspaceSymbolVisitor', () => {
   });
 
   describe('subroutine labels', () => {
-    it('extracts standalone O-block label as Key symbol (Fanuc)', () => {
+    it('extracts standalone O-block label as Module symbol (Fanuc)', () => {
       const symbols = getWorkspaceSymbols('O0001', TEST_URI, DialectType.FANUC);
 
       expect(symbols).toHaveLength(1);
       expect(symbols[0].name).toBe('O0001');
-      expect(symbols[0].kind).toBe(SymbolKind.Key);
+      expect(symbols[0].kind).toBe(SymbolKind.Module);
     });
 
-    it('extracts standalone O-block label as Key symbol (Haas)', () => {
+    it('extracts standalone O-block label as Module symbol (Haas)', () => {
       const symbols = getWorkspaceSymbols('O0001', TEST_URI, DialectType.HAAS);
 
       expect(symbols).toHaveLength(1);
       expect(symbols[0].name).toBe('O0001');
-      expect(symbols[0].kind).toBe(SymbolKind.Key);
+      expect(symbols[0].kind).toBe(SymbolKind.Module);
     });
   });
 


### PR DESCRIPTION
## Summary

Addresses all review findings from PR #123 code review. PR #123 was merged before review fixes could be applied, so this is a follow-up.

- **P1**: Add E2E tests for `indexingEnabled=false` and `maxSymbols` limit (AC steps 7-8)
- **P2**: Remove out-of-scope ViewCube camera-sync and theta fixes (belong in separate PR)
- **P2**: Add logger callback to `WorkspaceSymbolIndex.extractSymbols` catch block
- **P2**: Change `SymbolKind.Key` → `SymbolKind.Module` for subroutine labels
- **P2**: Document `setMaxSymbols` deferred-effect behavior in JSDoc
- **P2**: Fix `package.json` description: "all G-code files" → "open G-code files"
- **P3**: Extract shared `DEFAULT_MAX_SEARCH_RESULTS` constant
- **P3**: Fix declaration style to match comma-chain pattern in `server.ts`
- **P3**: Add `.catch()` error handling for `applyWorkspaceSettings()` calls
- **P3**: Fix misleading test comment about `maxSymbols` limit behavior
- **P3**: Use domain-specific `WaitConditionTimeoutError` in `testUtils`
- **P3**: Fix PR #123 body test count (46 → 47, already updated via API)

## Test plan

- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] All 1226 unit tests pass (66 suites)
- [x] ESLint clean on changed files
- [ ] E2E tests for settings wiring (new tests — need Extension Host run)

Closes review thread on #123.