### PR TITLE
refactor(visualizer): inject ProgramInterpreter into GCodePathExtractor

### DIFF
--- a/src/client/VisualizerService.ts
+++ b/src/client/VisualizerService.ts
@@ -10,17 +10,12 @@
 import { DialectType } from '../constants';
 import { LexerFactory } from '../lexer/LexerFactory';
 import { ParserFactory } from '../parser/ParserFactory';
+import { GCodeInterpreter } from '../visualizer/GCodeInterpreter';
 import { GCodePathExtractor } from '../visualizer/GCodePathExtractor';
 import { VariableResolutionService } from '../visualizer/VariableResolutionService';
 import { VariableDefinitions, VisualizerResult } from '../visualizer/types';
 
 export class VisualizerService {
-  private readonly extractor: GCodePathExtractor;
-
-  constructor() {
-    this.extractor = new GCodePathExtractor();
-  }
-
   /**
    * Parses `text` and extracts the complete tool path.
    *
@@ -43,7 +38,9 @@ export class VisualizerService {
       const parser = ParserFactory.create(dialect, tokens, text);
       const ast = parser.parseProgram();
       const environment = new VariableResolutionService({ settingsVariables }).resolve();
-      const data = this.extractor.extract(ast, environment);
+      const extractor = new GCodePathExtractor();
+      const interpreter = new GCodeInterpreter(extractor, undefined, environment);
+      const data = extractor.extract(ast, interpreter);
       return { success: true, data };
     } catch (error: unknown) {
       const errorMessage =

--- a/src/test/GCodePathExtractor.test.ts
+++ b/src/test/GCodePathExtractor.test.ts
@@ -2,21 +2,32 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { GCodeLexer } from '../lexer/GCodeLexer';
 import { LinuxCNCParser } from '../parser/dialects/LinuxCNCParser';
+import { GCodeInterpreter } from '../visualizer/GCodeInterpreter';
 import { GCodePathExtractor } from '../visualizer/GCodePathExtractor';
 import { MotionType, ToolPathData } from '../visualizer/types';
 import { VariableEnvironment } from '../visualizer/VariableEnvironment';
 
 describe('GCodePathExtractor', () => {
   /**
-   * Helper: tokenise, parse, and extract path data from a G-code string.
+   * Helper: tokenise, parse, and construct an extractor + interpreter
+   * pipeline ready to run against the extractor's `extract` method.
    */
-  function extract(input: string): ToolPathData {
+  function buildPipeline(input: string, env?: VariableEnvironment) {
     const lexer = new GCodeLexer();
     const tokens = lexer.tokenize(input);
     const parser = new LinuxCNCParser(tokens, input);
     const ast = parser.parseProgram();
     const extractor = new GCodePathExtractor();
-    return extractor.extract(ast);
+    const interpreter = new GCodeInterpreter(extractor, undefined, env);
+    return { ast, extractor, interpreter };
+  }
+
+  /**
+   * Helper: tokenise, parse, and extract path data from a G-code string.
+   */
+  function extract(input: string): ToolPathData {
+    const { ast, extractor, interpreter } = buildPipeline(input);
+    return extractor.extract(ast, interpreter);
   }
 
   // ---------------------------------------------------------------------------
@@ -665,12 +676,11 @@ G2 X20 Z0 I5 K0
       input: string,
       variables: ReadonlyMap<string | number, number>
     ): ToolPathData {
-      const lexer = new GCodeLexer();
-      const tokens = lexer.tokenize(input);
-      const parser = new LinuxCNCParser(tokens, input);
-      const ast = parser.parseProgram();
-      const extractor = new GCodePathExtractor();
-      return extractor.extract(ast, VariableEnvironment.fromEntries(variables));
+      const { ast, extractor, interpreter } = buildPipeline(
+        input,
+        VariableEnvironment.fromEntries(variables)
+      );
+      return extractor.extract(ast, interpreter);
     }
 
     it('uses initial variables for numbered variable references', () => {

--- a/src/visualizer/GCodeInterpreter.ts
+++ b/src/visualizer/GCodeInterpreter.ts
@@ -30,10 +30,10 @@ import { DEFAULT_GCODE_CONFIG } from '../config/defaults';
 import { normalizeCommand } from '../utils/GCodeNormalizer';
 import { MODAL_MOTION_COMMANDS } from '../constants/GCodeCommands';
 import { GCodeExpressionEvaluator } from './GCodeExpressionEvaluator';
-import { InterpreterConfig, MotionHandler } from './types';
+import { InterpreterConfig, MotionHandler, ProgramInterpreter } from './types';
 import { VariableEnvironment } from './VariableEnvironment';
 
-export class GCodeInterpreter {
+export class GCodeInterpreter implements ProgramInterpreter {
   private readonly variableEnvironment: VariableEnvironment;
   private readonly expressionEvaluator: GCodeExpressionEvaluator;
   private readonly options: InterpreterConfig;

--- a/src/visualizer/GCodePathExtractor.ts
+++ b/src/visualizer/GCodePathExtractor.ts
@@ -32,8 +32,6 @@ import {
 } from '../constants/GCodeCommands';
 import { ARC_PLANE_CONFIGS, ArcPlane, ArcPlaneConfig } from './ArcPlane';
 import { GCodeExpressionEvaluator } from './GCodeExpressionEvaluator';
-import { GCodeInterpreter } from './GCodeInterpreter';
-import { VariableEnvironment } from './VariableEnvironment';
 import {
   MotionContext,
   MotionHandler,
@@ -41,6 +39,7 @@ import {
   PathBounds,
   PathPoint,
   PathSegment,
+  ProgramInterpreter,
   ReferencedVariable,
   ToolPathData,
 } from './types';
@@ -234,10 +233,10 @@ export class GCodePathExtractor implements MotionHandler {
    * can be reused across multiple documents.
    *
    * @param program     - Parsed G-code program AST
-   * @param variableEnvironment - Optional pre-configured variable environment
-   *                      (from {@link VariableResolutionService})
+   * @param interpreter - Program interpreter that will walk the AST and
+   *                      dispatch motion commands back to this extractor
    */
-  extract(program: ProgramNode, variableEnvironment?: VariableEnvironment): ToolPathData {
+  extract(program: ProgramNode, interpreter: ProgramInterpreter): ToolPathData {
     this.segments = [];
     this.currentPosition = { x: 0, y: 0, z: 0 };
     this.isAbsoluteMode = true;
@@ -245,7 +244,6 @@ export class GCodePathExtractor implements MotionHandler {
     this.modalFeedRate = null;
     this.modalSpindleSpeed = null;
 
-    const interpreter = new GCodeInterpreter(this, undefined, variableEnvironment);
     interpreter.interpret(program);
     const bounds = computeBounds(this.segments);
     const referencedVariables = this.buildReferencedVariables(interpreter);
@@ -256,7 +254,7 @@ export class GCodePathExtractor implements MotionHandler {
    * Builds the list of referenced variables from the interpreter's
    * tracking data, including their final resolved values after execution.
    */
-  private buildReferencedVariables(interpreter: GCodeInterpreter): readonly ReferencedVariable[] {
+  private buildReferencedVariables(interpreter: ProgramInterpreter): readonly ReferencedVariable[] {
     const named: ReferencedVariable[] = [];
 
     for (const key of interpreter.referencedVariables) {

--- a/src/visualizer/types.ts
+++ b/src/visualizer/types.ts
@@ -8,6 +8,7 @@
 
 import { DialectType } from '../constants';
 import { AxisParameterNode } from '../parser/nodes/AxisParameterNode';
+import { ProgramNode } from '../parser/nodes/ProgramNode';
 import { GCodeExpressionEvaluator } from './GCodeExpressionEvaluator';
 
 /**
@@ -218,6 +219,18 @@ export interface MotionHandler {
     parameters: readonly AxisParameterNode[],
     evaluator: GCodeExpressionEvaluator
   ): void;
+}
+
+/**
+ * Minimal contract the path extractor needs from a program interpreter.
+ * Implemented by {@link GCodeInterpreter}. Exists so the extractor can be
+ * decoupled from the concrete interpreter — the composition root
+ * ({@link VisualizerService}) owns construction and wires both together.
+ */
+export interface ProgramInterpreter {
+  interpret(program: ProgramNode): void;
+  readonly referencedVariables: ReadonlySet<string | number>;
+  getVariableValue(name: string | number): number | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Introduce `ProgramInterpreter` interface in `src/visualizer/types.ts`; `GCodeInterpreter` now `implements` it.
- `GCodePathExtractor.extract(program, interpreter)` takes the interpreter as a required parameter — no more internal `new GCodeInterpreter(...)`, decoupling the extractor from the concrete interpreter.
- `VisualizerService.extractToolPath()` becomes the composition root: builds extractor + interpreter fresh per call so modal/variable state cannot leak across documents.
- Pure refactor, no production behavior change. Test helpers factored into a shared `buildPipeline()`; ~52 existing test cases untouched.

Closes #131

## Manual testing

1. Check out this branch and run `npm install && npm run build`.
2. Launch the Extension Host (F5 in VS Code).
3. Open any `.nc` file (e.g. one of `src/test/fixtures/*.nc`).
4. Run **G-code: Show 3D Visualizer** from the command palette.
5. Confirm the tool path renders identically to main — same segments, same bounds, same referenced variables panel.
6. Edit the file, rerun, confirm state does not leak between invocations.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors — pre-existing warnings only)
- [x] `npm test` passes (1252 / 1252)
- [x] `npm run build` passes
- [ ] Manual visualizer smoke test in Extension Host