### PR TITLE
refactor(providers): tighten provider DI and boundaries (#133)

### DIFF
--- a/src/providers/BaseProvider.ts
+++ b/src/providers/BaseProvider.ts
@@ -8,8 +8,9 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { DialectType } from '../constants';
 import { AnalysisOptions, AnalysisResults } from './AnalysisResults';
-import { DocumentState, DocumentStateManager, GCodeSettings } from './DocumentStateManager';
+import { DocumentState, GCodeSettings } from './DocumentStateManager';
 import { IDataProvider } from './IDataProvider';
+import { IDocumentStateManager } from './IDocumentStateManager';
 
 /**
  * Abstract base provider class
@@ -20,7 +21,7 @@ import { IDataProvider } from './IDataProvider';
  * - Dialect-specific data providers
  */
 export abstract class BaseProvider {
-  constructor(protected readonly documentStateManager: DocumentStateManager) {}
+  constructor(protected readonly documentStateManager: IDocumentStateManager) {}
 
   /**
    * Get or parse document state for a given text document

--- a/src/providers/CompletionContextDetector.ts
+++ b/src/providers/CompletionContextDetector.ts
@@ -8,7 +8,8 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Position } from 'vscode-languageserver/node';
 
 import { GCodeSymbols } from '../constants';
-import { DocumentStateManager, GCodeSettings } from './DocumentStateManager';
+import { GCodeSettings } from './DocumentStateManager';
+import { IDocumentStateManager } from './IDocumentStateManager';
 import { CompletionUtils } from './CompletionUtils';
 
 /**
@@ -43,7 +44,7 @@ export interface ContextInfo {
  * completion should be provided.
  */
 export class CompletionContextDetector {
-  constructor(private readonly documentStateManager: DocumentStateManager) {}
+  constructor(private readonly documentStateManager: IDocumentStateManager) {}
 
   /**
    * Detect completion context from cursor position

--- a/src/providers/CompletionProvider.ts
+++ b/src/providers/CompletionProvider.ts
@@ -15,7 +15,8 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CompletionItem, Position } from 'vscode-languageserver/node';
 
 import { CompletionItemTypes, DialectType } from '../constants';
-import { DocumentStateManager, GCodeSettings } from './DocumentStateManager';
+import { GCodeSettings } from './DocumentStateManager';
+import { IDocumentStateManager } from './IDocumentStateManager';
 import { DocumentationBuilder } from './DocumentationBuilder';
 import { BaseProvider } from './BaseProvider';
 import { CompletionContext, CompletionContextDetector } from './CompletionContextDetector';
@@ -47,7 +48,7 @@ export class CompletionProvider extends BaseProvider {
   private readonly documentationBuilder = new DocumentationBuilder();
   private readonly strategies: ReadonlyMap<CompletionContext, CompletionStrategy>;
 
-  constructor(documentStateManager: DocumentStateManager) {
+  constructor(documentStateManager: IDocumentStateManager) {
     super(documentStateManager);
     this.contextDetector = new CompletionContextDetector(documentStateManager);
     this.strategies = new Map<CompletionContext, CompletionStrategy>([

--- a/src/providers/DefinitionProvider.ts
+++ b/src/providers/DefinitionProvider.ts
@@ -10,6 +10,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Position } from '../parser/nodes';
 import { GCodeSettings } from './DocumentStateManager';
 import { BaseProvider } from './BaseProvider';
+import { IDocumentStateManager } from './IDocumentStateManager';
 import { VariableAnalysisService } from './VariableAnalysisService';
 
 /**
@@ -20,7 +21,12 @@ import { VariableAnalysisService } from './VariableAnalysisService';
  * at the cursor position.
  */
 export class DefinitionProvider extends BaseProvider {
-  private readonly variableAnalysisService = new VariableAnalysisService();
+  constructor(
+    documentStateManager: IDocumentStateManager,
+    private readonly variableAnalysisService: VariableAnalysisService
+  ) {
+    super(documentStateManager);
+  }
 
   /**
    * Provide the definition location for a variable at the given position

--- a/src/providers/DocumentFormattingProvider.ts
+++ b/src/providers/DocumentFormattingProvider.ts
@@ -1,7 +1,8 @@
 import { TextDocument, TextEdit } from 'vscode-languageserver-textdocument';
 
 import { FormatterService } from './FormatterService';
-import { DocumentStateManager, GCodeSettings } from './DocumentStateManager';
+import { GCodeSettings } from './DocumentStateManager';
+import { IDocumentStateManager } from './IDocumentStateManager';
 import { DialectType } from '../constants';
 import { ProgramNode, Range } from '../parser/nodes';
 import { FormatterConfig } from '../formatter/types';
@@ -16,7 +17,7 @@ import { FormatterConfig } from '../formatter/types';
 export class DocumentFormattingProvider {
   constructor(
     private formatter: FormatterService,
-    private stateManager?: DocumentStateManager
+    private stateManager?: IDocumentStateManager
   ) {}
 
   /**

--- a/src/providers/DocumentFormattingProvider.ts
+++ b/src/providers/DocumentFormattingProvider.ts
@@ -17,7 +17,7 @@ import { FormatterConfig } from '../formatter/types';
 export class DocumentFormattingProvider {
   constructor(
     private formatter: FormatterService,
-    private stateManager?: IDocumentStateManager
+    private documentStateManager?: IDocumentStateManager
   ) {}
 
   /**
@@ -69,10 +69,13 @@ export class DocumentFormattingProvider {
     settings: FormatterConfig,
     dialect?: DialectType
   ): ProgramNode | undefined {
-    if (!this.stateManager) return undefined;
+    if (!this.documentStateManager) return undefined;
 
     const gcodeSettings: GCodeSettings = { formatter: settings, dialect };
-    const state = this.stateManager.getOrParseDocumentFromTextDocument(document, gcodeSettings);
+    const state = this.documentStateManager.getOrParseDocumentFromTextDocument(
+      document,
+      gcodeSettings
+    );
     return state.ast;
   }
 }

--- a/src/providers/DocumentHighlightProvider.ts
+++ b/src/providers/DocumentHighlightProvider.ts
@@ -10,6 +10,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Position } from '../parser/nodes';
 import { GCodeSettings } from './DocumentStateManager';
 import { BaseProvider } from './BaseProvider';
+import { IDocumentStateManager } from './IDocumentStateManager';
 import { VariableAnalysisService } from './VariableAnalysisService';
 
 /**
@@ -18,7 +19,12 @@ import { VariableAnalysisService } from './VariableAnalysisService';
  * Highlights all occurrences of a variable at the cursor position.
  */
 export class DocumentHighlightProvider extends BaseProvider {
-  private readonly variableAnalysisService = new VariableAnalysisService();
+  constructor(
+    documentStateManager: IDocumentStateManager,
+    private readonly variableAnalysisService: VariableAnalysisService
+  ) {
+    super(documentStateManager);
+  }
 
   /**
    * Provide document highlights for a variable at the given position

--- a/src/providers/DocumentStateManager.ts
+++ b/src/providers/DocumentStateManager.ts
@@ -23,6 +23,7 @@ import { AnalysisOptions, AnalysisResults } from './AnalysisResults';
 import { AstAnalysisService } from './AstAnalysisService';
 import { SemanticAnalyzer } from './SemanticAnalyzer';
 import { IDataProvider } from './IDataProvider';
+import { IDocumentStateManager } from './IDocumentStateManager';
 import { DataProviderFactory } from './DataProviderFactory';
 import { FormatterConfig } from '../formatter/types';
 
@@ -55,7 +56,7 @@ export interface DocumentState {
  * Manages cached document states to avoid redundant parsing.
  * Invalidates cache when documents change.
  */
-export class DocumentStateManager {
+export class DocumentStateManager implements IDocumentStateManager {
   private documentStates = new Map<string, DocumentState>();
   private documentVersions = new Map<string, number>();
   private dataProviderCache = new Map<string, IDataProvider>();
@@ -220,6 +221,16 @@ export class DocumentStateManager {
       state.analysis = undefined;
       state.needsReparse = true;
     }
+  }
+
+  /**
+   * Run AST-level analysis (variables, errors, optional semantic tokens) on
+   * a pre-parsed program. Unlike {@link getAnalysis}, this does not touch the
+   * document cache or run semantic analysis — it is a direct, uncached pass
+   * suitable for callers that already hold a {@link DocumentState}.
+   */
+  analyzeAst(ast: ProgramNode, options: AnalysisOptions = {}): AnalysisResults {
+    return this.analysisService.analyze(ast, options);
   }
 
   /**

--- a/src/providers/DocumentStateManager.ts
+++ b/src/providers/DocumentStateManager.ts
@@ -225,9 +225,10 @@ export class DocumentStateManager implements IDocumentStateManager {
 
   /**
    * Run AST-level analysis (variables, errors, optional semantic tokens) on
-   * a pre-parsed program. Unlike {@link getAnalysis}, this does not touch the
-   * document cache or run semantic analysis — it is a direct, uncached pass
-   * suitable for callers that already hold a {@link DocumentState}.
+   * a pre-parsed program. Unlike {@link getAnalysisFromTextDocument}, this
+   * does not touch the document cache or run semantic analysis — it is a
+   * direct, uncached pass suitable for callers that already hold a
+   * {@link DocumentState}.
    */
   analyzeAst(ast: ProgramNode, options: AnalysisOptions = {}): AnalysisResults {
     return this.analysisService.analyze(ast, options);

--- a/src/providers/FoldingRangeProvider.ts
+++ b/src/providers/FoldingRangeProvider.ts
@@ -4,7 +4,8 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { BaseAstVisitor } from '../parser/BaseAstVisitor';
 import { AstTraverser } from '../parser/AstTraverser';
 import { IfStatementNode, SubroutineLabelNode, WhileStatementNode } from '../parser/nodes';
-import { DocumentStateManager, GCodeSettings } from './DocumentStateManager';
+import { GCodeSettings } from './DocumentStateManager';
+import { IDocumentStateManager } from './IDocumentStateManager';
 
 /**
  * Provides code folding ranges for G-code control structures.
@@ -79,7 +80,7 @@ export class FoldingRangeProvider extends BaseAstVisitor<void> {
    */
   provideFoldingRanges(
     document: TextDocument,
-    documentStateManager: DocumentStateManager,
+    documentStateManager: IDocumentStateManager,
     settings: GCodeSettings
   ): FoldingRange[] {
     this.foldingRanges = [];

--- a/src/providers/HoverProvider.ts
+++ b/src/providers/HoverProvider.ts
@@ -130,7 +130,7 @@ export class HoverProvider extends BaseProvider {
     let analysis: AnalysisResults | undefined;
     if (node instanceof VariableAssignmentNode || node instanceof VariableReferenceNode) {
       if (!state.analysis) {
-        state.analysis = this.documentStateManager['analysisService'].analyze(state.ast);
+        state.analysis = this.documentStateManager.analyzeAst(state.ast);
       }
       analysis = state.analysis;
     }

--- a/src/providers/IDocumentStateManager.ts
+++ b/src/providers/IDocumentStateManager.ts
@@ -8,13 +8,13 @@
  * require a real provider-side consumer, not speculative future use.
  */
 
-import { TextDocument } from 'vscode-languageserver-textdocument';
+import type { TextDocument } from 'vscode-languageserver-textdocument';
 
-import { DialectType } from '../constants';
-import { ProgramNode } from '../parser/nodes';
-import { AnalysisOptions, AnalysisResults } from './AnalysisResults';
-import { DocumentState, GCodeSettings } from './DocumentStateManager';
-import { IDataProvider } from './IDataProvider';
+import type { DialectType } from '../constants';
+import type { ProgramNode } from '../parser/nodes';
+import type { AnalysisOptions, AnalysisResults } from './AnalysisResults';
+import type { DocumentState, GCodeSettings } from './DocumentStateManager';
+import type { IDataProvider } from './IDataProvider';
 
 export interface IDocumentStateManager {
   /**

--- a/src/providers/IDocumentStateManager.ts
+++ b/src/providers/IDocumentStateManager.ts
@@ -1,0 +1,46 @@
+/**
+ * Narrow interface exposing the {@link DocumentStateManager} surface
+ * consumed by LSP providers and provider-adjacent services.
+ *
+ * Kept intentionally minimal — server-only concerns (cache invalidation,
+ * content change application, document removal) are deliberately excluded
+ * because providers should not touch them. Expanding this interface should
+ * require a real provider-side consumer, not speculative future use.
+ */
+
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+import { DialectType } from '../constants';
+import { ProgramNode } from '../parser/nodes';
+import { AnalysisOptions, AnalysisResults } from './AnalysisResults';
+import { DocumentState, GCodeSettings } from './DocumentStateManager';
+import { IDataProvider } from './IDataProvider';
+
+export interface IDocumentStateManager {
+  /**
+   * Get (or parse) cached document state for a text document.
+   */
+  getOrParseDocumentFromTextDocument(
+    document: TextDocument,
+    settings: GCodeSettings
+  ): DocumentState;
+
+  /**
+   * Get (or compute) analysis results for a text document.
+   */
+  getAnalysisFromTextDocument(
+    document: TextDocument,
+    settings: GCodeSettings,
+    options?: AnalysisOptions
+  ): AnalysisResults;
+
+  /**
+   * Run AST-level analysis on a pre-parsed program without touching the cache.
+   */
+  analyzeAst(ast: ProgramNode, options?: AnalysisOptions): AnalysisResults;
+
+  /**
+   * Get the dialect-specific data provider.
+   */
+  getDataProvider(dialect?: DialectType): IDataProvider;
+}

--- a/src/providers/ReferencesProvider.ts
+++ b/src/providers/ReferencesProvider.ts
@@ -10,6 +10,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Position, VariableAssignmentNode, VariableReferenceNode } from '../parser/nodes';
 import { GCodeSettings } from './DocumentStateManager';
 import { BaseProvider } from './BaseProvider';
+import { IDocumentStateManager } from './IDocumentStateManager';
 import { VariableAnalysisService } from './VariableAnalysisService';
 
 /**
@@ -20,7 +21,12 @@ import { VariableAnalysisService } from './VariableAnalysisService';
  * at the cursor position.
  */
 export class ReferencesProvider extends BaseProvider {
-  private readonly variableAnalysisService = new VariableAnalysisService();
+  constructor(
+    documentStateManager: IDocumentStateManager,
+    private readonly variableAnalysisService: VariableAnalysisService
+  ) {
+    super(documentStateManager);
+  }
 
   /**
    * Provide all reference locations for a variable at the given position

--- a/src/providers/RenameProvider.ts
+++ b/src/providers/RenameProvider.ts
@@ -10,6 +10,7 @@ import { TextEdit, WorkspaceEdit } from 'vscode-languageserver/node';
 import { Position, Range, VariableAssignmentNode, VariableReferenceNode } from '../parser/nodes';
 import { GCodeSettings } from './DocumentStateManager';
 import { BaseProvider } from './BaseProvider';
+import { IDocumentStateManager } from './IDocumentStateManager';
 import { VariableAnalysisService } from './VariableAnalysisService';
 import { formatVariableName } from './RenameUtils';
 
@@ -19,7 +20,12 @@ import { formatVariableName } from './RenameUtils';
  * Handles variable renaming requests from the language server.
  */
 export class RenameProvider extends BaseProvider {
-  private readonly variableAnalysisService = new VariableAnalysisService();
+  constructor(
+    documentStateManager: IDocumentStateManager,
+    private readonly variableAnalysisService: VariableAnalysisService
+  ) {
+    super(documentStateManager);
+  }
 
   /**
    * Prepare rename - check if position is on a variable and return range/placeholder

--- a/src/providers/SemanticTokensProvider.ts
+++ b/src/providers/SemanticTokensProvider.ts
@@ -1,7 +1,8 @@
 import { SemanticTokens, SemanticTokensLegend } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
-import { DocumentStateManager, GCodeSettings } from './DocumentStateManager';
+import { GCodeSettings } from './DocumentStateManager';
+import { IDocumentStateManager } from './IDocumentStateManager';
 
 export enum SemanticTokenTypes {
   Keyword = 'keyword',
@@ -29,7 +30,7 @@ export const SEMANTIC_TOKENS_LEGEND: SemanticTokensLegend = {
 export class SemanticTokensProvider {
   static provide(
     document: TextDocument,
-    stateManager: DocumentStateManager,
+    stateManager: IDocumentStateManager,
     settings: GCodeSettings
   ): SemanticTokens {
     const analysis = stateManager.getAnalysisFromTextDocument(document, settings, {

--- a/src/providers/SemanticTokensProvider.ts
+++ b/src/providers/SemanticTokensProvider.ts
@@ -30,10 +30,10 @@ export const SEMANTIC_TOKENS_LEGEND: SemanticTokensLegend = {
 export class SemanticTokensProvider {
   static provide(
     document: TextDocument,
-    stateManager: IDocumentStateManager,
+    documentStateManager: IDocumentStateManager,
     settings: GCodeSettings
   ): SemanticTokens {
-    const analysis = stateManager.getAnalysisFromTextDocument(document, settings, {
+    const analysis = documentStateManager.getAnalysisFromTextDocument(document, settings, {
       includeTokens: true,
     });
     return { data: analysis.tokens?.data ?? [] };

--- a/src/providers/completion/CommandCompletionStrategy.ts
+++ b/src/providers/completion/CommandCompletionStrategy.ts
@@ -15,12 +15,13 @@ import {
   MAX_SNIPPET_PARAMETERS,
 } from '../../constants';
 import { GROUP_SORT_ORDER, DEFAULT_GROUP_SORT_PREFIX } from '../../databases/types';
-import { DocumentStateManager, GCodeSettings } from '../DocumentStateManager';
+import { GCodeSettings } from '../DocumentStateManager';
+import { IDocumentStateManager } from '../IDocumentStateManager';
 import { ContextInfo } from '../CompletionContextDetector';
 import { CompletionStrategy } from './CompletionStrategy';
 
 export class CommandCompletionStrategy implements CompletionStrategy {
-  constructor(private readonly documentStateManager: DocumentStateManager) {}
+  constructor(private readonly documentStateManager: IDocumentStateManager) {}
 
   provide(
     _document: TextDocument,

--- a/src/providers/completion/ExpressionCompletionStrategy.ts
+++ b/src/providers/completion/ExpressionCompletionStrategy.ts
@@ -9,7 +9,8 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver/node';
 
 import { CompletionItemTypes, OPERATORS_SORT_PREFIX, DialectType } from '../../constants';
-import { DocumentStateManager, GCodeSettings } from '../DocumentStateManager';
+import { GCodeSettings } from '../DocumentStateManager';
+import { IDocumentStateManager } from '../IDocumentStateManager';
 import { ContextInfo } from '../CompletionContextDetector';
 import { CompletionStrategy } from './CompletionStrategy';
 import { VariableCompletionStrategy } from './VariableCompletionStrategy';
@@ -19,7 +20,7 @@ export class ExpressionCompletionStrategy implements CompletionStrategy {
   private readonly variableStrategy: VariableCompletionStrategy;
   private readonly functionStrategy: FunctionCompletionStrategy;
 
-  constructor(private readonly documentStateManager: DocumentStateManager) {
+  constructor(private readonly documentStateManager: IDocumentStateManager) {
     this.variableStrategy = new VariableCompletionStrategy(documentStateManager);
     this.functionStrategy = new FunctionCompletionStrategy(documentStateManager);
   }

--- a/src/providers/completion/FunctionCompletionStrategy.ts
+++ b/src/providers/completion/FunctionCompletionStrategy.ts
@@ -9,12 +9,13 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CompletionItem, CompletionItemKind, InsertTextFormat } from 'vscode-languageserver/node';
 
 import { CompletionItemTypes, GCodeSymbols, DialectType } from '../../constants';
-import { DocumentStateManager, GCodeSettings } from '../DocumentStateManager';
+import { GCodeSettings } from '../DocumentStateManager';
+import { IDocumentStateManager } from '../IDocumentStateManager';
 import { ContextInfo } from '../CompletionContextDetector';
 import { CompletionStrategy } from './CompletionStrategy';
 
 export class FunctionCompletionStrategy implements CompletionStrategy {
-  constructor(private readonly documentStateManager: DocumentStateManager) {}
+  constructor(private readonly documentStateManager: IDocumentStateManager) {}
 
   provide(
     _document: TextDocument,

--- a/src/providers/completion/KeywordCompletionStrategy.ts
+++ b/src/providers/completion/KeywordCompletionStrategy.ts
@@ -9,12 +9,13 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver/node';
 
 import { CompletionItemTypes, GCodeSymbols, DialectType } from '../../constants';
-import { DocumentStateManager, GCodeSettings } from '../DocumentStateManager';
+import { GCodeSettings } from '../DocumentStateManager';
+import { IDocumentStateManager } from '../IDocumentStateManager';
 import { ContextInfo } from '../CompletionContextDetector';
 import { CompletionStrategy } from './CompletionStrategy';
 
 export class KeywordCompletionStrategy implements CompletionStrategy {
-  constructor(private readonly documentStateManager: DocumentStateManager) {}
+  constructor(private readonly documentStateManager: IDocumentStateManager) {}
 
   provide(
     _document: TextDocument,

--- a/src/providers/completion/ParameterCompletionStrategy.ts
+++ b/src/providers/completion/ParameterCompletionStrategy.ts
@@ -9,12 +9,13 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver/node';
 
 import { CompletionItemTypes, GCodeSymbols, DialectType } from '../../constants';
-import { DocumentStateManager, GCodeSettings } from '../DocumentStateManager';
+import { GCodeSettings } from '../DocumentStateManager';
+import { IDocumentStateManager } from '../IDocumentStateManager';
 import { ContextInfo } from '../CompletionContextDetector';
 import { CompletionStrategy } from './CompletionStrategy';
 
 export class ParameterCompletionStrategy implements CompletionStrategy {
-  constructor(private readonly documentStateManager: DocumentStateManager) {}
+  constructor(private readonly documentStateManager: IDocumentStateManager) {}
 
   provide(
     _document: TextDocument,

--- a/src/providers/completion/VariableCompletionStrategy.ts
+++ b/src/providers/completion/VariableCompletionStrategy.ts
@@ -8,13 +8,14 @@
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver/node';
 
-import { DocumentStateManager, GCodeSettings } from '../DocumentStateManager';
+import { GCodeSettings } from '../DocumentStateManager';
+import { IDocumentStateManager } from '../IDocumentStateManager';
 import { ContextInfo } from '../CompletionContextDetector';
 import { formatVariableName } from '../RenameUtils';
 import { CompletionStrategy } from './CompletionStrategy';
 
 export class VariableCompletionStrategy implements CompletionStrategy {
-  constructor(private readonly documentStateManager: DocumentStateManager) {}
+  constructor(private readonly documentStateManager: IDocumentStateManager) {}
 
   provide(
     document: TextDocument,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -154,12 +154,13 @@ function toGCodeSettings(config: GCodeConfig): GCodeSettings {
   };
 }
 
+// Shared stateless service — one instance reused across the four providers
+// that resolve variable symbols at a cursor position.
+const variableAnalysisService = new VariableAnalysisService();
+
 const formatterService = new FormatterService(),
   // Create document state manager and providers
   documentStateManager = new DocumentStateManager(),
-  // Shared stateless service — one instance reused across the four providers
-  // that resolve variable symbols at a cursor position.
-  variableAnalysisService = new VariableAnalysisService(),
   documentFormatter = new DocumentFormattingProvider(formatterService, documentStateManager),
   definitionProvider = new DefinitionProvider(documentStateManager, variableAnalysisService),
   referencesProvider = new ReferencesProvider(documentStateManager, variableAnalysisService),

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -29,6 +29,7 @@ import { CompletionProvider } from '../providers/CompletionProvider';
 import { FoldingRangeProvider } from '../providers/FoldingRangeProvider';
 import { GCodeConfig } from '../config/types';
 import { ServerConfigProvider } from '../config/server-config-provider/ServerConfigProvider';
+import { VariableAnalysisService } from '../providers/VariableAnalysisService';
 import { WorkspaceSymbolIndex } from '../providers/WorkspaceSymbolIndex';
 import { WorkspaceSymbolProvider } from '../providers/WorkspaceSymbolProvider';
 
@@ -156,11 +157,17 @@ function toGCodeSettings(config: GCodeConfig): GCodeSettings {
 const formatterService = new FormatterService(),
   // Create document state manager and providers
   documentStateManager = new DocumentStateManager(),
+  // Shared stateless service — one instance reused across the four providers
+  // that resolve variable symbols at a cursor position.
+  variableAnalysisService = new VariableAnalysisService(),
   documentFormatter = new DocumentFormattingProvider(formatterService, documentStateManager),
-  definitionProvider = new DefinitionProvider(documentStateManager),
-  referencesProvider = new ReferencesProvider(documentStateManager),
-  renameProvider = new RenameProvider(documentStateManager),
-  documentHighlightProvider = new DocumentHighlightProvider(documentStateManager),
+  definitionProvider = new DefinitionProvider(documentStateManager, variableAnalysisService),
+  referencesProvider = new ReferencesProvider(documentStateManager, variableAnalysisService),
+  renameProvider = new RenameProvider(documentStateManager, variableAnalysisService),
+  documentHighlightProvider = new DocumentHighlightProvider(
+    documentStateManager,
+    variableAnalysisService
+  ),
   documentSymbolProvider = new DocumentSymbolProvider(documentStateManager),
   hoverProvider = new HoverProvider(documentStateManager),
   diagnosticsProvider = new DiagnosticsProvider(documentStateManager),

--- a/src/test/DocumentHighlightProvider.test.ts
+++ b/src/test/DocumentHighlightProvider.test.ts
@@ -9,6 +9,7 @@ import { DEFAULT_GCODE_CONFIG } from '../config/defaults';
 import { Position } from '../parser/nodes';
 import { DocumentHighlightProvider } from '../providers/DocumentHighlightProvider';
 import { DocumentStateManager, GCodeSettings } from '../providers/DocumentStateManager';
+import { VariableAnalysisService } from '../providers/VariableAnalysisService';
 
 const TEST_SETTINGS: GCodeSettings = {
   formatter: DEFAULT_GCODE_CONFIG.formatter,
@@ -19,7 +20,7 @@ describe('DocumentHighlightProvider', () => {
 
   beforeEach(() => {
     stateManager = new DocumentStateManager();
-    provider = new DocumentHighlightProvider(stateManager);
+    provider = new DocumentHighlightProvider(stateManager, new VariableAnalysisService());
   });
 
   describe('provideDocumentHighlights', () => {

--- a/src/test/RenameProvider.test.ts
+++ b/src/test/RenameProvider.test.ts
@@ -8,6 +8,7 @@ import { DEFAULT_GCODE_CONFIG } from '../config/defaults';
 import { Position } from '../parser/nodes';
 import { DocumentStateManager, GCodeSettings } from '../providers/DocumentStateManager';
 import { RenameProvider } from '../providers/RenameProvider';
+import { VariableAnalysisService } from '../providers/VariableAnalysisService';
 
 const TEST_SETTINGS: GCodeSettings = {
   formatter: DEFAULT_GCODE_CONFIG.formatter,
@@ -18,7 +19,7 @@ describe('RenameProvider', () => {
 
   beforeEach(() => {
     stateManager = new DocumentStateManager();
-    provider = new RenameProvider(stateManager);
+    provider = new RenameProvider(stateManager, new VariableAnalysisService());
   });
 
   describe('prepareRename', () => {

--- a/src/test/providers/DefinitionProvider.test.ts
+++ b/src/test/providers/DefinitionProvider.test.ts
@@ -8,6 +8,7 @@ import { DEFAULT_GCODE_CONFIG } from '../../config/defaults';
 import { Position } from '../../parser/nodes';
 import { DefinitionProvider } from '../../providers/DefinitionProvider';
 import { DocumentStateManager, GCodeSettings } from '../../providers/DocumentStateManager';
+import { VariableAnalysisService } from '../../providers/VariableAnalysisService';
 
 const TEST_SETTINGS: GCodeSettings = {
   formatter: DEFAULT_GCODE_CONFIG.formatter,
@@ -18,7 +19,7 @@ describe('DefinitionProvider', () => {
 
   beforeEach(() => {
     stateManager = new DocumentStateManager();
-    provider = new DefinitionProvider(stateManager);
+    provider = new DefinitionProvider(stateManager, new VariableAnalysisService());
   });
 
   describe('provideDefinition', () => {

--- a/src/test/providers/ReferencesProvider.test.ts
+++ b/src/test/providers/ReferencesProvider.test.ts
@@ -8,6 +8,7 @@ import { DEFAULT_GCODE_CONFIG } from '../../config/defaults';
 import { Position } from '../../parser/nodes';
 import { ReferencesProvider } from '../../providers/ReferencesProvider';
 import { DocumentStateManager, GCodeSettings } from '../../providers/DocumentStateManager';
+import { VariableAnalysisService } from '../../providers/VariableAnalysisService';
 
 const TEST_SETTINGS: GCodeSettings = {
   formatter: DEFAULT_GCODE_CONFIG.formatter,
@@ -18,7 +19,7 @@ describe('ReferencesProvider', () => {
 
   beforeEach(() => {
     stateManager = new DocumentStateManager();
-    provider = new ReferencesProvider(stateManager);
+    provider = new ReferencesProvider(stateManager, new VariableAnalysisService());
   });
 
   describe('provideReferences', () => {


### PR DESCRIPTION
## Summary

- **A.** `VariableAnalysisService` is now constructed once in `server.ts` and injected into `DefinitionProvider`, `ReferencesProvider`, `DocumentHighlightProvider`, and `RenameProvider` via their constructors — no more four fresh instances.
- **B.** New `IDocumentStateManager` interface in `src/providers/IDocumentStateManager.ts` narrows the provider-facing surface to exactly the four members providers touch. `BaseProvider` and every other class that took the concrete `DocumentStateManager` (completion strategies, `CompletionContextDetector`, `DocumentFormattingProvider`, `FoldingRangeProvider`, `SemanticTokensProvider`) now depend on the interface. `DocumentStateManager` gains `implements IDocumentStateManager`.
- **C.** New public `analyzeAst(ast)` method on `DocumentStateManager` (also on the interface) that delegates to the private `AstAnalysisService`. `HoverProvider:133` now calls it normally instead of `this.documentStateManager['analysisService'].analyze(...)`.

No production behavior change.

Closes #133

## Manual testing

1. Open a `.nc` file in the Extension Host (`npm run build` then F5 or an installed `.vsix`).
2. **Go to Definition** — put the cursor on a `#<foo>` reference, `F12` → jumps to the assignment.
3. **Find All References** — `Shift+F12` on a variable → lists the assignment and all references.
4. **Rename** — `F2` on a variable, enter a new name → all occurrences update.
5. **Document Highlight** — place cursor on a variable → other occurrences highlight.
6. **Hover** — hover a variable, a G/M command, an operator, a function, and an axis parameter → tooltip content renders for each.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors, pre-existing warnings only)
- [x] `npm test` — 1252/1252 passing
- [x] `npm run build`
- [ ] Manual LSP smoke: go-to-definition, find-references, rename, document-highlight, hover in a real `.nc` file