### PR TITLE
feat(workspace-symbols): scan workspace on init and track file changes (#126)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,12 @@ import {
 export const GCODE_LANGUAGE_ID = 'gcode';
 
 /**
+ * File extensions (without leading dot) that the workspace indexing
+ * service treats as G-code source files.
+ */
+export const GCODE_INDEX_EXTENSIONS: readonly string[] = ['nc', 'gcode', 'tap', 'ngc', 'cnc'];
+
+/**
  * G-code dialect types supported by the extension
  */
 export enum DialectType {

--- a/src/e2e/suite/workspaceSymbolIndexing.test.ts
+++ b/src/e2e/suite/workspaceSymbolIndexing.test.ts
@@ -1,0 +1,153 @@
+/**
+ * E2E tests for the workspace-wide symbol indexing pipeline.
+ *
+ * These tests verify that the language server discovers and tracks G-code
+ * files on disk without the user opening them — exercising
+ * `WorkspaceIndexingService` end-to-end via the real LSP file watcher
+ * registered through `workspace/didChangeWatchedFiles`.
+ */
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import { TestUtils } from '../testUtils';
+
+const FIXTURE_PREFIX = 'ws-fs-watch-';
+
+function fixtureName(suffix: string): string {
+  return `${FIXTURE_PREFIX}${suffix}`;
+}
+
+async function findSymbolsByName(
+  query: string,
+  predicate: (symbol: vscode.SymbolInformation) => boolean
+): Promise<vscode.SymbolInformation[]> {
+  const symbols = await TestUtils.waitForCondition(
+    async () =>
+      vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+        'vscode.executeWorkspaceSymbolProvider',
+        query
+      ),
+    (result) => Array.isArray(result) && result.some(predicate)
+  );
+  return symbols.filter(predicate);
+}
+
+async function waitForAbsence(
+  query: string,
+  predicate: (symbol: vscode.SymbolInformation) => boolean,
+  timeout = 10000
+): Promise<void> {
+  await TestUtils.waitForCondition(
+    async () =>
+      vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+        'vscode.executeWorkspaceSymbolProvider',
+        query
+      ),
+    (result) => Array.isArray(result) && !result.some(predicate),
+    timeout
+  );
+}
+
+suite('Workspace Symbol Indexing (file watcher)', () => {
+  TestUtils.setup();
+
+  test('Indexes a file written to disk without opening an editor', async () => {
+    const filename = fixtureName('created.nc');
+    const workspacePath = TestUtils.getWorkspaceFolderPath();
+    const filePath = path.join(workspacePath, filename);
+    fs.writeFileSync(filePath, 'O701 SUB\nG0 X10\nO701 ENDSUB\n', 'utf8');
+
+    try {
+      const matches = await findSymbolsByName('O701', (s) => s.name === 'O701');
+      assert.ok(matches.length > 0, 'Should index O701 from a file that was never opened');
+    } finally {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    }
+  });
+
+  test('Re-indexes a file when it changes on disk', async () => {
+    const filename = fixtureName('changed.nc');
+    const workspacePath = TestUtils.getWorkspaceFolderPath();
+    const filePath = path.join(workspacePath, filename);
+    fs.writeFileSync(filePath, 'O702 SUB\nO702 ENDSUB\n', 'utf8');
+
+    try {
+      await findSymbolsByName('O702', (s) => s.name === 'O702');
+
+      fs.writeFileSync(filePath, 'O702 SUB\nO702 ENDSUB\nO703 SUB\nO703 ENDSUB\n', 'utf8');
+
+      const matches = await findSymbolsByName('O703', (s) => s.name === 'O703');
+      assert.ok(matches.length > 0, 'Should pick up symbols added by external edit');
+    } finally {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    }
+  });
+
+  test('Removes symbols when a file is deleted via vscode.workspace.fs', async () => {
+    const filename = fixtureName('deleted.nc');
+    const workspacePath = TestUtils.getWorkspaceFolderPath();
+    const filePath = path.join(workspacePath, filename);
+    const fileUri = vscode.Uri.file(filePath);
+    fs.writeFileSync(filePath, 'O704 SUB\nO704 ENDSUB\n', 'utf8');
+
+    try {
+      await findSymbolsByName('O704', (s) => s.name === 'O704');
+
+      await vscode.workspace.fs.delete(fileUri);
+
+      await waitForAbsence('O704', (s) => s.name === 'O704');
+    } finally {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    }
+  });
+
+  test('Updates the index when a file is renamed', async () => {
+    const oldName = fixtureName('rename-old.nc');
+    const newName = fixtureName('rename-new.nc');
+    const workspacePath = TestUtils.getWorkspaceFolderPath();
+    const oldPath = path.join(workspacePath, oldName);
+    const newPath = path.join(workspacePath, newName);
+    fs.writeFileSync(oldPath, 'O705 SUB\nO705 ENDSUB\n', 'utf8');
+
+    try {
+      const initial = await findSymbolsByName('O705', (s) => s.name === 'O705');
+      const oldUri = initial[0].location.uri.toString();
+
+      await vscode.workspace.fs.rename(vscode.Uri.file(oldPath), vscode.Uri.file(newPath));
+
+      const after = await TestUtils.waitForCondition(
+        async () =>
+          vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+            'vscode.executeWorkspaceSymbolProvider',
+            'O705'
+          ),
+        (result) =>
+          Array.isArray(result) &&
+          result.some((s) => s.name === 'O705' && s.location.uri.toString() !== oldUri)
+      );
+
+      const newUriHits = after.filter(
+        (s) => s.name === 'O705' && s.location.uri.fsPath === newPath
+      );
+      assert.ok(newUriHits.length > 0, 'Renamed file should be indexed under its new URI');
+    } finally {
+      if (fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
+      if (fs.existsSync(newPath)) fs.unlinkSync(newPath);
+    }
+  });
+
+  suiteTeardown(() => {
+    const workspacePath = TestUtils.getWorkspaceFolderPath();
+    for (const entry of fs.readdirSync(workspacePath)) {
+      if (entry.startsWith(FIXTURE_PREFIX)) {
+        try {
+          fs.unlinkSync(path.join(workspacePath, entry));
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    }
+  });
+});

--- a/src/providers/WorkspaceIndexingService.ts
+++ b/src/providers/WorkspaceIndexingService.ts
@@ -39,7 +39,7 @@ export enum WorkspaceFileChangeType {
 /** Subset of LSP `FileEvent` consumed by the service. */
 export interface WorkspaceFileEvent {
   readonly uri: string;
-  readonly type: WorkspaceFileChangeType | 1 | 2 | 3;
+  readonly type: WorkspaceFileChangeType;
 }
 
 /** Minimal progress reporter shape compatible with LSP `WorkDoneProgressReporter`. */
@@ -111,27 +111,36 @@ export class WorkspaceIndexingService {
    * `setImmediate` yield between batches so the event loop stays responsive.
    */
   async scanRoots(roots: readonly string[]): Promise<void> {
-    if (!this.enabled) return;
+    // Remember the roots even when indexing is currently disabled, so a later
+    // setEnabled(true) can rescan them without the caller re-passing them.
     this.lastRoots = [...roots];
+    if (!this.enabled) return;
 
+    // Dialect is captured once for the whole scan; per-folder dialects would
+    // require resolving the dialect per file (or per workspace folder).
     const dialect = await this.getDialect();
     const progress = (await this.progressFactory?.()) ?? undefined;
     progress?.begin('Indexing G-code files');
 
+    const allFiles: string[] = [];
+    for (const root of roots) {
+      const files = await this.collectFiles(root);
+      allFiles.push(...files);
+    }
+    const total = allFiles.length;
+
     let processed = 0;
     try {
-      for (const root of roots) {
-        const files = await this.collectFiles(root);
-        for (let i = 0; i < files.length; i += SCAN_BATCH_SIZE) {
-          if (!this.enabled) return;
-          const batch = files.slice(i, i + SCAN_BATCH_SIZE);
-          for (const filePath of batch) {
-            await this.indexFile(filePath, dialect);
-            processed++;
-            progress?.report(0, `Indexed ${processed} file${processed === 1 ? '' : 's'}`);
-          }
-          await yieldToEventLoop();
+      for (let i = 0; i < total; i += SCAN_BATCH_SIZE) {
+        if (!this.enabled) return;
+        const batch = allFiles.slice(i, i + SCAN_BATCH_SIZE);
+        for (const filePath of batch) {
+          await this.indexFile(filePath, dialect);
+          processed++;
+          const percentage = total > 0 ? Math.floor((processed / total) * 100) : 100;
+          progress?.report(percentage, `Indexed ${processed} of ${total}`);
         }
+        await yieldToEventLoop();
       }
     } finally {
       progress?.done();
@@ -147,7 +156,7 @@ export class WorkspaceIndexingService {
 
     for (const change of changes) {
       const uri = change.uri;
-      this.pendingChanges.set(uri, change.type as WorkspaceFileChangeType);
+      this.pendingChanges.set(uri, change.type);
 
       const existing = this.debounceTimers.get(uri);
       if (existing) clearTimeout(existing);
@@ -187,6 +196,9 @@ export class WorkspaceIndexingService {
   private async indexFile(filePath: string, dialect: DialectType): Promise<void> {
     try {
       const content = await fs.readFile(filePath, 'utf8');
+      // Re-check after the awaited read so a mid-scan disable can't write into
+      // an index that was just cleared by setEnabled(false).
+      if (!this.enabled) return;
       const uri = pathToFileURL(filePath).toString();
       this.symbolIndex.indexFile(uri, content, dialect);
     } catch (error: unknown) {
@@ -205,7 +217,7 @@ export class WorkspaceIndexingService {
   private async walkDirectory(dir: string, collected: string[]): Promise<void> {
     let entries: Dirent[];
     try {
-      entries = (await fs.readdir(dir, { withFileTypes: true })) as unknown as Dirent[];
+      entries = await fs.readdir(dir, { withFileTypes: true, encoding: 'utf8' });
     } catch (error: unknown) {
       this.logger?.(
         `Failed to read directory ${dir}: ${error instanceof Error ? error.message : String(error)}`

--- a/src/providers/WorkspaceIndexingService.ts
+++ b/src/providers/WorkspaceIndexingService.ts
@@ -1,0 +1,254 @@
+/**
+ * Workspace Indexing Service
+ *
+ * Discovers G-code files across configured workspace roots, indexes them
+ * via the {@link WorkspaceSymbolIndex} without opening editors, and reacts
+ * to file system change events delivered through
+ * `workspace/didChangeWatchedFiles`.
+ *
+ * The service is intentionally decoupled from the LSP `Connection` — it
+ * accepts dependencies via {@link WorkspaceIndexingDependencies} so it can
+ * be unit-tested against real temp directories without an LSP host.
+ */
+import type { Dirent } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { DialectType, GCODE_INDEX_EXTENSIONS } from '../constants';
+import { WorkspaceSymbolIndex } from './WorkspaceSymbolIndex';
+
+const SCAN_BATCH_SIZE = 50;
+const DEFAULT_DEBOUNCE_MS = 300;
+
+const SKIPPED_DIRECTORIES: ReadonlySet<string> = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'out',
+  '.vscode-test',
+]);
+
+/** LSP `FileChangeType` values, replicated to keep this module dependency-light. */
+export enum WorkspaceFileChangeType {
+  Created = 1,
+  Changed = 2,
+  Deleted = 3,
+}
+
+/** Subset of LSP `FileEvent` consumed by the service. */
+export interface WorkspaceFileEvent {
+  readonly uri: string;
+  readonly type: WorkspaceFileChangeType | 1 | 2 | 3;
+}
+
+/** Minimal progress reporter shape compatible with LSP `WorkDoneProgressReporter`. */
+export interface ProgressReporter {
+  begin(title: string, percentage?: number, message?: string): void;
+  report(percentage: number, message?: string): void;
+  done(): void;
+}
+
+export interface WorkspaceIndexingDependencies {
+  readonly symbolIndex: WorkspaceSymbolIndex;
+  readonly getDialect: () => DialectType | Promise<DialectType>;
+  readonly logger?: (message: string) => void;
+  readonly progressFactory?: () => Promise<ProgressReporter | undefined>;
+  readonly debounceMs?: number;
+}
+
+export class WorkspaceIndexingService {
+  private readonly symbolIndex: WorkspaceSymbolIndex;
+  private readonly getDialect: () => DialectType | Promise<DialectType>;
+  private readonly logger?: (message: string) => void;
+  private readonly progressFactory?: () => Promise<ProgressReporter | undefined>;
+  private readonly debounceMs: number;
+
+  private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly pendingChanges = new Map<string, WorkspaceFileChangeType>();
+
+  private enabled = true;
+  private lastRoots: readonly string[] = [];
+
+  constructor(deps: WorkspaceIndexingDependencies) {
+    this.symbolIndex = deps.symbolIndex;
+    this.getDialect = deps.getDialect;
+    this.logger = deps.logger;
+    this.progressFactory = deps.progressFactory;
+    this.debounceMs = deps.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /**
+   * Enable or disable workspace indexing.
+   *
+   * Disabling clears all timers and the symbol index. Re-enabling triggers
+   * a fresh scan of the most recently scanned roots, if any.
+   */
+  setEnabled(enabled: boolean): Promise<void> {
+    if (this.enabled === enabled) {
+      return Promise.resolve();
+    }
+    this.enabled = enabled;
+    if (!enabled) {
+      this.clearTimers();
+      this.symbolIndex.clear();
+      return Promise.resolve();
+    }
+    if (this.lastRoots.length === 0) {
+      return Promise.resolve();
+    }
+    return this.scanRoots(this.lastRoots);
+  }
+
+  /**
+   * Walk the given workspace roots and index every G-code file found.
+   *
+   * Files are processed in batches of {@link SCAN_BATCH_SIZE} with a
+   * `setImmediate` yield between batches so the event loop stays responsive.
+   */
+  async scanRoots(roots: readonly string[]): Promise<void> {
+    if (!this.enabled) return;
+    this.lastRoots = [...roots];
+
+    const dialect = await this.getDialect();
+    const progress = (await this.progressFactory?.()) ?? undefined;
+    progress?.begin('Indexing G-code files');
+
+    let processed = 0;
+    try {
+      for (const root of roots) {
+        const files = await this.collectFiles(root);
+        for (let i = 0; i < files.length; i += SCAN_BATCH_SIZE) {
+          if (!this.enabled) return;
+          const batch = files.slice(i, i + SCAN_BATCH_SIZE);
+          for (const filePath of batch) {
+            await this.indexFile(filePath, dialect);
+            processed++;
+            progress?.report(0, `Indexed ${processed} file${processed === 1 ? '' : 's'}`);
+          }
+          await yieldToEventLoop();
+        }
+      }
+    } finally {
+      progress?.done();
+    }
+  }
+
+  /**
+   * Apply a batch of file change notifications. Each URI is debounced
+   * independently so bursts of edits coalesce into a single re-index.
+   */
+  handleFileEvents(changes: readonly WorkspaceFileEvent[]): void {
+    if (!this.enabled) return;
+
+    for (const change of changes) {
+      const uri = change.uri;
+      this.pendingChanges.set(uri, change.type as WorkspaceFileChangeType);
+
+      const existing = this.debounceTimers.get(uri);
+      if (existing) clearTimeout(existing);
+
+      const timer = setTimeout(() => {
+        this.debounceTimers.delete(uri);
+        const finalType = this.pendingChanges.get(uri);
+        this.pendingChanges.delete(uri);
+        if (finalType === undefined) return;
+        this.processChange(uri, finalType).catch((error: unknown) => {
+          this.logger?.(
+            `Failed to process change for ${uri}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        });
+      }, this.debounceMs);
+      this.debounceTimers.set(uri, timer);
+    }
+  }
+
+  private async processChange(uri: string, type: WorkspaceFileChangeType): Promise<void> {
+    if (!this.enabled) return;
+
+    if (type === WorkspaceFileChangeType.Deleted) {
+      this.symbolIndex.removeFile(uri);
+      return;
+    }
+
+    const filePath = uriToFilePath(uri);
+    if (filePath === undefined) return;
+
+    const dialect = await this.getDialect();
+    await this.indexFile(filePath, dialect);
+  }
+
+  private async indexFile(filePath: string, dialect: DialectType): Promise<void> {
+    try {
+      const content = await fs.readFile(filePath, 'utf8');
+      const uri = pathToFileURL(filePath).toString();
+      this.symbolIndex.indexFile(uri, content, dialect);
+    } catch (error: unknown) {
+      this.logger?.(
+        `Failed to index ${filePath}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  private async collectFiles(root: string): Promise<string[]> {
+    const collected: string[] = [];
+    await this.walkDirectory(root, collected);
+    return collected;
+  }
+
+  private async walkDirectory(dir: string, collected: string[]): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = (await fs.readdir(dir, { withFileTypes: true })) as unknown as Dirent[];
+    } catch (error: unknown) {
+      this.logger?.(
+        `Failed to read directory ${dir}: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (SKIPPED_DIRECTORIES.has(entry.name)) continue;
+        await this.walkDirectory(fullPath, collected);
+      } else if (entry.isFile() && hasIndexedExtension(entry.name)) {
+        collected.push(fullPath);
+      }
+    }
+  }
+
+  private clearTimers(): void {
+    for (const timer of this.debounceTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.debounceTimers.clear();
+    this.pendingChanges.clear();
+  }
+}
+
+function hasIndexedExtension(name: string): boolean {
+  const dot = name.lastIndexOf('.');
+  if (dot < 0) return false;
+  const ext = name.slice(dot + 1).toLowerCase();
+  return GCODE_INDEX_EXTENSIONS.includes(ext);
+}
+
+function uriToFilePath(uri: string): string | undefined {
+  if (!uri.startsWith('file:')) return undefined;
+  try {
+    return fileURLToPath(uri);
+  } catch {
+    return undefined;
+  }
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -50,14 +50,15 @@ const configProvider = new ServerConfigProvider(connection);
 
 // Captured at onInitialize so onInitialized can register dynamic capabilities
 // against the workspace folders the client started with.
-let initializeParams: InitializeParams | undefined;
 let workspaceFolders: readonly WorkspaceFolder[] = [];
+let dynamicWatchedFilesSupported = false;
 
 // Server settings synced from the client
 connection.onInitialize((params: InitializeParams): InitializeResult => {
   connection.console.log('G-code Language Server initializing...');
-  initializeParams = params;
   workspaceFolders = params.workspaceFolders ?? [];
+  dynamicWatchedFilesSupported =
+    params.capabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration === true;
 
   return {
     capabilities: {
@@ -143,12 +144,21 @@ connection.onDidChangeConfiguration(() => {
 
 /**
  * Reads workspace-level settings from the config provider and propagates
- * them to the workspace symbol index and indexing service.
+ * them to the workspace symbol index and indexing service. When indexing is
+ * enabled this also (re)scans the known workspace roots — `setEnabled` is a
+ * no-op when the value is unchanged, and `onDidChangeConfiguration` clears
+ * the in-memory index ahead of each call, so without an explicit rescan a
+ * config change would leave the workspace permanently empty.
  */
 async function applyWorkspaceSettings(): Promise<void> {
   const config = await configProvider.getConfig();
   workspaceSymbolIndex.setMaxSymbols(config.workspace.maxSymbols);
   await workspaceIndexingService.setEnabled(config.workspace.indexingEnabled);
+  if (!config.workspace.indexingEnabled) return;
+
+  const roots = workspaceFoldersToPaths(workspaceFolders);
+  if (roots.length === 0) return;
+  await workspaceIndexingService.scanRoots(roots);
 }
 
 /**
@@ -485,38 +495,43 @@ connection.languages.diagnostics.on(async (params) => {
 connection.onInitialized(() => {
   connection.console.log('G-code Language Server initialized');
 
-  // Dynamically register a workspace file watcher so the client streams
-  // create/change/delete events for G-code files we don't have open.
-  connection.client
-    .register(DidChangeWatchedFilesNotification.type, {
-      watchers: [{ globPattern: '**/*.{nc,gcode,tap,ngc,cnc}' }],
-    })
-    .catch((error: Error) => {
-      connection.console.error(`Failed to register file watcher: ${error.message}`);
-    });
-
-  applyWorkspaceSettings()
-    .then(() => {
-      const roots = workspaceFoldersToPaths(workspaceFolders);
-      if (roots.length === 0) return;
-      // Fire-and-forget initial scan; errors are logged inside the service.
-      workspaceIndexingService.scanRoots(roots).catch((error: Error) => {
-        connection.console.error(`Workspace indexing scan failed: ${error.message}`);
+  if (dynamicWatchedFilesSupported) {
+    // Dynamically register a workspace file watcher so the client streams
+    // create/change/delete events for G-code files we don't have open.
+    // Register one RelativePattern per workspace folder rather than a bare
+    // string glob: vscode-languageclient maps RelativePattern → vscode
+    // RelativePattern, which uses VS Code's per-folder file watcher backend.
+    // The bare-string glob path goes through VS Code's global watcher,
+    // which has multi-second startup latency on Linux (parcel-watcher) and
+    // misses events for files created/deleted within that warm-up window.
+    const watchers = workspaceFolders.map((folder) => ({
+      globPattern: {
+        baseUri: folder.uri,
+        pattern: '**/*.{nc,gcode,tap,ngc,cnc}',
+      },
+    }));
+    connection.client
+      .register(DidChangeWatchedFilesNotification.type, { watchers })
+      .catch((error: Error) => {
+        connection.console.error(`Failed to register file watcher: ${error.message}`);
       });
-    })
-    .catch((error: Error) => {
-      connection.console.error(`Failed to apply workspace settings: ${error.message}`);
-    });
+  } else {
+    connection.console.warn(
+      'Client does not advertise didChangeWatchedFiles dynamic registration; ' +
+        'workspace file watching disabled.'
+    );
+  }
 
-  // Reference initializeParams so it isn't reported as unused — it's also
-  // captured for any future server features that need the original payload.
-  void initializeParams;
+  // applyWorkspaceSettings handles the initial scan when indexing is enabled.
+  applyWorkspaceSettings().catch((error: Error) => {
+    connection.console.error(`Failed to apply workspace settings: ${error.message}`);
+  });
 });
 
 connection.onDidChangeWatchedFiles((params: DidChangeWatchedFilesParams) => {
   const events: WorkspaceFileEvent[] = params.changes.map((change) => ({
     uri: change.uri,
-    type: change.type as 1 | 2 | 3,
+    type: change.type,
   }));
   workspaceIndexingService.handleFileEvents(events);
 });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,12 +1,17 @@
+import { fileURLToPath } from 'node:url';
+
 import {
   CodeActionKind,
   createConnection,
   DidChangeTextDocumentNotification,
+  DidChangeWatchedFilesNotification,
+  DidChangeWatchedFilesParams,
   InitializeParams,
   InitializeResult,
   ProposedFeatures,
   TextDocuments,
   TextDocumentSyncKind,
+  WorkspaceFolder,
 } from 'vscode-languageserver/node';
 import { DefinitionProvider } from '../providers/DefinitionProvider';
 import { DiagnosticsProvider } from '../providers/DiagnosticsProvider';
@@ -30,6 +35,11 @@ import { FoldingRangeProvider } from '../providers/FoldingRangeProvider';
 import { GCodeConfig } from '../config/types';
 import { ServerConfigProvider } from '../config/server-config-provider/ServerConfigProvider';
 import { VariableAnalysisService } from '../providers/VariableAnalysisService';
+import {
+  ProgressReporter,
+  WorkspaceFileEvent,
+  WorkspaceIndexingService,
+} from '../providers/WorkspaceIndexingService';
 import { WorkspaceSymbolIndex } from '../providers/WorkspaceSymbolIndex';
 import { WorkspaceSymbolProvider } from '../providers/WorkspaceSymbolProvider';
 
@@ -38,9 +48,16 @@ const connection = createConnection(ProposedFeatures.all);
 const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
 const configProvider = new ServerConfigProvider(connection);
 
+// Captured at onInitialize so onInitialized can register dynamic capabilities
+// against the workspace folders the client started with.
+let initializeParams: InitializeParams | undefined;
+let workspaceFolders: readonly WorkspaceFolder[] = [];
+
 // Server settings synced from the client
-connection.onInitialize((_params: InitializeParams): InitializeResult => {
+connection.onInitialize((params: InitializeParams): InitializeResult => {
   connection.console.log('G-code Language Server initializing...');
+  initializeParams = params;
+  workspaceFolders = params.workspaceFolders ?? [];
 
   return {
     capabilities: {
@@ -125,12 +142,13 @@ connection.onDidChangeConfiguration(() => {
 });
 
 /**
- * Reads workspace-level settings from the config provider
- * and applies them to the workspace symbol index.
+ * Reads workspace-level settings from the config provider and propagates
+ * them to the workspace symbol index and indexing service.
  */
 async function applyWorkspaceSettings(): Promise<void> {
   const config = await configProvider.getConfig();
   workspaceSymbolIndex.setMaxSymbols(config.workspace.maxSymbols);
+  await workspaceIndexingService.setEnabled(config.workspace.indexingEnabled);
 }
 
 /**
@@ -175,7 +193,22 @@ const formatterService = new FormatterService(),
   codeActionProvider = new CodeActionProvider(),
   completionProvider = new CompletionProvider(documentStateManager),
   workspaceSymbolIndex = new WorkspaceSymbolIndex(undefined, (msg) => connection.console.warn(msg)),
-  workspaceSymbolProvider = new WorkspaceSymbolProvider(workspaceSymbolIndex);
+  workspaceSymbolProvider = new WorkspaceSymbolProvider(workspaceSymbolIndex),
+  workspaceIndexingService = new WorkspaceIndexingService({
+    symbolIndex: workspaceSymbolIndex,
+    getDialect: async () => {
+      const config = await configProvider.getConfig();
+      return config.dialect;
+    },
+    logger: (msg) => connection.console.warn(msg),
+    progressFactory: async (): Promise<ProgressReporter | undefined> => {
+      try {
+        return await connection.window.createWorkDoneProgress();
+      } catch {
+        return undefined;
+      }
+    },
+  });
 
 connection.onDocumentFormatting(async (params) => {
   const document = documents.get(params.textDocument.uri);
@@ -451,10 +484,58 @@ connection.languages.diagnostics.on(async (params) => {
 
 connection.onInitialized(() => {
   connection.console.log('G-code Language Server initialized');
-  applyWorkspaceSettings().catch((error: Error) => {
-    connection.console.error(`Failed to apply workspace settings: ${error.message}`);
-  });
+
+  // Dynamically register a workspace file watcher so the client streams
+  // create/change/delete events for G-code files we don't have open.
+  connection.client
+    .register(DidChangeWatchedFilesNotification.type, {
+      watchers: [{ globPattern: '**/*.{nc,gcode,tap,ngc,cnc}' }],
+    })
+    .catch((error: Error) => {
+      connection.console.error(`Failed to register file watcher: ${error.message}`);
+    });
+
+  applyWorkspaceSettings()
+    .then(() => {
+      const roots = workspaceFoldersToPaths(workspaceFolders);
+      if (roots.length === 0) return;
+      // Fire-and-forget initial scan; errors are logged inside the service.
+      workspaceIndexingService.scanRoots(roots).catch((error: Error) => {
+        connection.console.error(`Workspace indexing scan failed: ${error.message}`);
+      });
+    })
+    .catch((error: Error) => {
+      connection.console.error(`Failed to apply workspace settings: ${error.message}`);
+    });
+
+  // Reference initializeParams so it isn't reported as unused — it's also
+  // captured for any future server features that need the original payload.
+  void initializeParams;
 });
+
+connection.onDidChangeWatchedFiles((params: DidChangeWatchedFilesParams) => {
+  const events: WorkspaceFileEvent[] = params.changes.map((change) => ({
+    uri: change.uri,
+    type: change.type as 1 | 2 | 3,
+  }));
+  workspaceIndexingService.handleFileEvents(events);
+});
+
+function workspaceFoldersToPaths(folders: readonly WorkspaceFolder[]): string[] {
+  const paths: string[] = [];
+  for (const folder of folders) {
+    try {
+      paths.push(fileURLToPath(folder.uri));
+    } catch (error: unknown) {
+      connection.console.warn(
+        `Skipping non-file workspace folder ${folder.uri}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+  return paths;
+}
 
 // Make the text document manager listen on the connection
 documents.listen(connection);

--- a/src/test/providers/WorkspaceIndexingService.test.ts
+++ b/src/test/providers/WorkspaceIndexingService.test.ts
@@ -254,5 +254,65 @@ describe('WorkspaceIndexingService', () => {
 
       expect(index.hasFile(uriOf(ncPath))).toBe(true);
     });
+
+    it('remembers roots passed while disabled so a later enable can scan them', async () => {
+      const ncPath = await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      const service = createService(index);
+
+      // Cold start with indexing turned off — scanRoots should still capture
+      // the roots even though it indexes nothing.
+      await service.setEnabled(false);
+      await service.scanRoots([tempDir]);
+      expect(index.getFileCount()).toBe(0);
+
+      await service.setEnabled(true);
+
+      expect(index.hasFile(uriOf(ncPath))).toBe(true);
+    });
+
+    it('does not write into a cleared index when disabled mid-scan', async () => {
+      // Create enough files that the scan straddles multiple awaited reads.
+      const filePaths: string[] = [];
+      for (let i = 0; i < 60; i++) {
+        filePaths.push(await writeFile(tempDir, `f${i}.nc`, SUBROUTINE_FILE));
+      }
+      const service = createService(index);
+
+      const scanPromise = service.scanRoots([tempDir]);
+      // Disable on the next microtask so some readFile calls are already in flight.
+      setImmediate(() => {
+        void service.setEnabled(false);
+      });
+      await scanPromise;
+
+      expect(index.getFileCount()).toBe(0);
+    });
+  });
+
+  describe('performance / event-loop yielding', () => {
+    it('yields to the event loop between batches and indexes every file', async () => {
+      const fileCount = 220;
+      for (let i = 0; i < fileCount; i++) {
+        await writeFile(tempDir, `f${i}.nc`, SUBROUTINE_FILE);
+      }
+
+      const service = createService(index);
+
+      let yieldCount = 0;
+      const scanPromise = service.scanRoots([tempDir]);
+      const interval = setInterval(() => {
+        yieldCount++;
+      }, 0);
+      try {
+        await scanPromise;
+      } finally {
+        clearInterval(interval);
+      }
+
+      expect(index.getFileCount()).toBe(fileCount);
+      // 220 files / 50-file batches = 5 yield points; the interval should have
+      // fired at least a few times, proving the scan released the event loop.
+      expect(yieldCount).toBeGreaterThanOrEqual(3);
+    });
   });
 });

--- a/src/test/providers/WorkspaceIndexingService.test.ts
+++ b/src/test/providers/WorkspaceIndexingService.test.ts
@@ -1,0 +1,258 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { DialectType } from '../../constants';
+import {
+  ProgressReporter,
+  WorkspaceIndexingService,
+} from '../../providers/WorkspaceIndexingService';
+import { WorkspaceSymbolIndex } from '../../providers/WorkspaceSymbolIndex';
+
+const TEST_DEBOUNCE_MS = 20;
+const SUBROUTINE_FILE = 'O100 SUB\nO100 ENDSUB\n';
+const ALT_FILE = 'O200 SUB\nO200 ENDSUB\n';
+
+function createService(
+  index: WorkspaceSymbolIndex,
+  options: {
+    dialect?: DialectType;
+    progress?: ProgressReporter;
+    logger?: (message: string) => void;
+    debounceMs?: number;
+  } = {}
+): WorkspaceIndexingService {
+  const progress = options.progress;
+  return new WorkspaceIndexingService({
+    symbolIndex: index,
+    getDialect: () => options.dialect ?? DialectType.LINUXCNC,
+    logger: options.logger,
+    progressFactory: progress ? () => Promise.resolve(progress) : undefined,
+    debounceMs: options.debounceMs ?? TEST_DEBOUNCE_MS,
+  });
+}
+
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'wsindex-'));
+}
+
+async function writeFile(dir: string, name: string, content: string): Promise<string> {
+  const full = path.join(dir, name);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, content, 'utf8');
+  return full;
+}
+
+function uriOf(filePath: string): string {
+  return pathToFileURL(filePath).toString();
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('WorkspaceIndexingService', () => {
+  let tempDir: string;
+  let index: WorkspaceSymbolIndex;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+    index = new WorkspaceSymbolIndex();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('scanRoots', () => {
+    it('indexes files matching the G-code extensions', async () => {
+      const ncPath = await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      const gcodePath = await writeFile(tempDir, 'b.gcode', ALT_FILE);
+      await writeFile(tempDir, 'c.txt', 'not gcode');
+
+      const service = createService(index);
+      await service.scanRoots([tempDir]);
+
+      expect(index.getFileCount()).toBe(2);
+      expect(index.hasFile(uriOf(ncPath))).toBe(true);
+      expect(index.hasFile(uriOf(gcodePath))).toBe(true);
+    });
+
+    it('indexes all configured G-code extensions', async () => {
+      await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      await writeFile(tempDir, 'b.gcode', SUBROUTINE_FILE);
+      await writeFile(tempDir, 'c.tap', SUBROUTINE_FILE);
+      await writeFile(tempDir, 'd.ngc', SUBROUTINE_FILE);
+      await writeFile(tempDir, 'e.cnc', SUBROUTINE_FILE);
+
+      const service = createService(index);
+      await service.scanRoots([tempDir]);
+
+      expect(index.getFileCount()).toBe(5);
+    });
+
+    it('skips blacklisted directories', async () => {
+      await writeFile(tempDir, 'src/main.nc', SUBROUTINE_FILE);
+      await writeFile(tempDir, 'node_modules/lib.nc', SUBROUTINE_FILE);
+      await writeFile(tempDir, '.git/HEAD.nc', SUBROUTINE_FILE);
+      await writeFile(tempDir, 'dist/build.nc', SUBROUTINE_FILE);
+      await writeFile(tempDir, 'out/o.nc', SUBROUTINE_FILE);
+      await writeFile(tempDir, '.vscode-test/v.nc', SUBROUTINE_FILE);
+
+      const service = createService(index);
+      await service.scanRoots([tempDir]);
+
+      expect(index.getFileCount()).toBe(1);
+    });
+
+    it('walks nested directories', async () => {
+      await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      await writeFile(tempDir, 'sub/b.nc', SUBROUTINE_FILE);
+      await writeFile(tempDir, 'sub/deep/c.nc', SUBROUTINE_FILE);
+
+      const service = createService(index);
+      await service.scanRoots([tempDir]);
+
+      expect(index.getFileCount()).toBe(3);
+    });
+
+    it('reports progress via the injected reporter', async () => {
+      await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      await writeFile(tempDir, 'b.nc', SUBROUTINE_FILE);
+
+      const begin = jest.fn();
+      const report = jest.fn();
+      const done = jest.fn();
+      const progress: ProgressReporter = { begin, report, done };
+      const service = createService(index, { progress });
+      await service.scanRoots([tempDir]);
+
+      expect(begin).toHaveBeenCalledTimes(1);
+      expect(report).toHaveBeenCalled();
+      expect(done).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not abort scan when a single file fails to read', async () => {
+      const okPath = await writeFile(tempDir, 'ok.nc', SUBROUTINE_FILE);
+      const badPath = await writeFile(tempDir, 'bad.nc', SUBROUTINE_FILE);
+      await fs.chmod(badPath, 0o000);
+
+      const logger = jest.fn();
+      const service = createService(index, { logger });
+      try {
+        await service.scanRoots([tempDir]);
+      } finally {
+        await fs.chmod(badPath, 0o644);
+      }
+
+      expect(index.hasFile(uriOf(okPath))).toBe(true);
+    });
+
+    it('is a no-op when disabled', async () => {
+      await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+
+      const service = createService(index);
+      await service.setEnabled(false);
+      await service.scanRoots([tempDir]);
+
+      expect(index.getFileCount()).toBe(0);
+    });
+  });
+
+  describe('handleFileEvents', () => {
+    it('indexes a created file after debounce', async () => {
+      const ncPath = await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      const service = createService(index);
+
+      service.handleFileEvents([{ uri: uriOf(ncPath), type: 1 }]);
+      expect(index.getFileCount()).toBe(0);
+
+      await delay(TEST_DEBOUNCE_MS * 3);
+
+      expect(index.hasFile(uriOf(ncPath))).toBe(true);
+    });
+
+    it('re-indexes a changed file', async () => {
+      const ncPath = await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      const service = createService(index);
+
+      service.handleFileEvents([{ uri: uriOf(ncPath), type: 1 }]);
+      await delay(TEST_DEBOUNCE_MS * 3);
+      expect(index.getSymbolCount()).toBe(1);
+
+      await fs.writeFile(ncPath, 'O100 SUB\nO100 ENDSUB\nO200 SUB\nO200 ENDSUB\n', 'utf8');
+      service.handleFileEvents([{ uri: uriOf(ncPath), type: 2 }]);
+      await delay(TEST_DEBOUNCE_MS * 3);
+
+      expect(index.getSymbolCount()).toBe(2);
+    });
+
+    it('removes symbols when a file is deleted', async () => {
+      const ncPath = await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      const service = createService(index);
+
+      service.handleFileEvents([{ uri: uriOf(ncPath), type: 1 }]);
+      await delay(TEST_DEBOUNCE_MS * 3);
+      expect(index.hasFile(uriOf(ncPath))).toBe(true);
+
+      service.handleFileEvents([{ uri: uriOf(ncPath), type: 3 }]);
+      await delay(TEST_DEBOUNCE_MS * 3);
+
+      expect(index.hasFile(uriOf(ncPath))).toBe(false);
+    });
+
+    it('coalesces rapid bursts via the per-URI debounce', async () => {
+      const ncPath = await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      const indexFileSpy = jest.spyOn(index, 'indexFile');
+
+      const service = createService(index, { debounceMs: 50 });
+      const uri = uriOf(ncPath);
+
+      for (let i = 0; i < 5; i++) {
+        service.handleFileEvents([{ uri, type: 2 }]);
+        await delay(10);
+      }
+      await delay(100);
+
+      expect(indexFileSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op when disabled', async () => {
+      const ncPath = await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      const service = createService(index);
+
+      await service.setEnabled(false);
+      service.handleFileEvents([{ uri: uriOf(ncPath), type: 1 }]);
+      await delay(TEST_DEBOUNCE_MS * 3);
+
+      expect(index.getFileCount()).toBe(0);
+    });
+  });
+
+  describe('setEnabled', () => {
+    it('clears the index when disabling', async () => {
+      await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      const service = createService(index);
+      await service.scanRoots([tempDir]);
+      expect(index.getFileCount()).toBe(1);
+
+      await service.setEnabled(false);
+
+      expect(index.getFileCount()).toBe(0);
+    });
+
+    it('rescans the previous roots when re-enabled', async () => {
+      const ncPath = await writeFile(tempDir, 'a.nc', SUBROUTINE_FILE);
+      const service = createService(index);
+      await service.scanRoots([tempDir]);
+
+      await service.setEnabled(false);
+      expect(index.getFileCount()).toBe(0);
+
+      await service.setEnabled(true);
+
+      expect(index.hasFile(uriOf(ncPath))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Makes workspace symbol search (`Ctrl+T`) work over a cold workspace and stay consistent when files are created, modified, renamed, or deleted outside the editor.

- **Initial scan** — new `WorkspaceIndexingService` walks `workspaceFolders` via `node:fs/promises`, indexes every `.nc`/`.gcode`/`.tap`/`.ngc`/`.cnc` file in 50-file batches with `setImmediate` yields, skipping `node_modules`, `.git`, `dist`, `out`, `.vscode-test`. Fires-and-forgets from `onInitialized` with a `WorkDoneProgress` reporter.
- **File watcher** — server-side dynamic LSP registration of `workspace/didChangeWatchedFiles` with one per-folder `RelativePattern` per workspace root (gated on `dynamicRegistration` client capability). Created / Changed → re-index; Deleted → `WorkspaceSymbolIndex.removeFile`. 300 ms per-URI debounce coalesces bursts.
- **`indexingEnabled` master switch** — toggling off clears the index and drops pending timers; toggling on (via `onDidChangeConfiguration` → `applyWorkspaceSettings`) explicitly rescans captured roots so config reloads don't leave the index empty.
- Client (`extension.ts`) unchanged — mechanism stays server-side.

Closes #126.

## Manual testing

1. `git checkout feat/workspace-file-watch && npm install && npm run build`
2. Launch the Extension Development Host (`F5`) with a workspace that has several `.nc`/`.gcode` files **none of which are open in editors**.
3. Hit `Ctrl+T` (or `Cmd+T` on macOS), type the name of a variable/subroutine you know exists in one of the closed files. → It should appear in results.
4. From a terminal (not VS Code), delete one of the indexed files: `rm some.nc`. Re-query `Ctrl+T` for a symbol from that file. → No results.
5. Rename a file on disk: `mv old.nc new.nc`. Re-query. → Symbols found under the new URI.
6. Edit a file externally: append a new variable assignment with `echo '#<newvar> = 5' >> file.nc`. Wait ~500 ms, re-query. → New variable is findable.
7. In settings, set `gcode.workspace.indexingEnabled` to `false`. → `Ctrl+T` over G-code symbols returns nothing. Flip back to `true`. → Results return without reloading the window.
8. Open a folder containing `node_modules/` with `.nc` files inside. → Those files are **not** indexed (verify nothing from `node_modules/` shows up in `Ctrl+T`).

### Automated verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm test` — 1271/1271 passing (17 tests in the new `WorkspaceIndexingService.test.ts`)
- `npm run test:e2e` — 86/86 passing, 3 consecutive runs with no flakes (4 new tests in `workspaceSymbolIndexing.test.ts` covering cold create, external edit, delete, rename)

## Notes

- Two follow-up issues filed in the architecture plan:
  - **#138** — honor `files.exclude` / `search.exclude` when scanning (requires client-side enumeration)
  - **#139** — apply `WorkDoneProgress` to other long-running operations project-wide
- Dialect is captured once per scan (workspace-level). Per-folder dialect support is noted as a known limitation inline in `WorkspaceIndexingService.ts`.