### PR TITLE
feat: add G64 command support for LinuxCNC, Fanuc, and Haas dialects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features and improvements -->
+- G64 command support: hover documentation and completions for G64 in LinuxCNC (Path Blending with P/Q tolerance parameters), Fanuc (Cutting Mode), and Haas (Cutting Mode) dialects
 
 ### Changed
 <!-- Updates and modifications -->

--- a/src/databases/dialects/FanucGCodeCommandDatabase.ts
+++ b/src/databases/dialects/FanucGCodeCommandDatabase.ts
@@ -315,6 +315,17 @@ export const GCODE_COMMANDS = new Map<string, GCodeCommandInfo>([
     },
   ],
   [
+    'G64',
+    {
+      command: 'G64',
+      name: 'Cutting Mode',
+      description:
+        'Enable cutting mode (normal path control). The controller does not decelerate at block boundaries, allowing smooth continuous motion. This is the default mode on most Fanuc controls. Contrast with G61 (exact stop) and G63 (tapping mode).',
+      group: CommandGroup.MOTION,
+      example: 'G64',
+    },
+  ],
+  [
     'G73',
     {
       command: 'G73',

--- a/src/databases/dialects/HaasGCodeCommandDatabase.ts
+++ b/src/databases/dialects/HaasGCodeCommandDatabase.ts
@@ -268,6 +268,17 @@ export const GCODE_COMMANDS = new Map<string, GCodeCommandInfo>([
     },
   ],
   [
+    'G64',
+    {
+      command: 'G64',
+      name: 'Cutting Mode',
+      description:
+        'Enable cutting mode (normal path control). The controller does not decelerate at block boundaries, allowing smooth continuous motion. Haas-compatible equivalent of Fanuc G64. Contrast with G61 (exact stop) and G63 (tapping mode).',
+      group: CommandGroup.MOTION,
+      example: 'G64',
+    },
+  ],
+  [
     'G73',
     {
       command: 'G73',

--- a/src/databases/dialects/LinuxcncGCodeCommandDatabase.ts
+++ b/src/databases/dialects/LinuxcncGCodeCommandDatabase.ts
@@ -267,6 +267,18 @@ export const GCODE_COMMANDS = new Map<string, GCodeCommandInfo>([
     },
   ],
   [
+    'G64',
+    {
+      command: 'G64',
+      name: 'Path Blending',
+      description:
+        'Enable path blending (continuous path) mode. The controller blends motion between blocks to maintain feed rate. P sets the maximum path deviation tolerance; Q sets the naive cam detector tolerance for colinear segment merging. Omitting P applies blending with no tolerance limit.',
+      group: CommandGroup.MOTION,
+      parameters: ['P', 'Q'],
+      example: 'G64 P0.01 Q0.005',
+    },
+  ],
+  [
     'G80',
     {
       command: 'G80',


### PR DESCRIPTION
## Description
Adds G64 command definitions (hover documentation and auto-completions) to the LinuxCNC, Fanuc, and Haas dialect databases. G64 was previously only defined for the Siemens dialect.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Related Issues
N/A

## Changes Made
- **LinuxCNC** (`LinuxcncGCodeCommandDatabase.ts`): Added G64 as *Path Blending* mode with optional `P` (path deviation tolerance) and `Q` (naive cam detector tolerance) parameters — the standard LinuxCNC path blending command
- **Fanuc** (`FanucGCodeCommandDatabase.ts`): Added G64 as *Cutting Mode* (no deceleration at block boundaries) — the standard Fanuc path control mode, no parameters
- **Haas** (`HaasGCodeCommandDatabase.ts`): Added G64 as *Cutting Mode* — Fanuc-compatible, no parameters
- `CHANGELOG.md`: Added entry under `[Unreleased] → Added`

## Testing
- [x] All existing tests pass (`npm test` — 1389 tests, 83 suites, all green)
- [x] Build succeeds (`npm run build`)
- [ ] New tests added for new functionality — not applicable; database entries are pure data with no branching logic, consistent with all other command entries in the database

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Documentation updated (CHANGELOG)
- [x] No new warnings generated
- [x] Type checking passes (`npm run typecheck` via build)
- [x] Build succeeds (`npm run build`)

## Additional Notes
Each dialect's G64 description explains the behavioural difference from the other modes (G61 exact stop, G63 tapping) so reviewers unfamiliar with CNC can understand the intent without consulting external docs.